### PR TITLE
feat: Implement Cliff-Based Access for Early Supporters

### DIFF
--- a/contracts/substream_contracts/src/lib.rs
+++ b/contracts/substream_contracts/src/lib.rs
@@ -82,9 +82,10 @@ pub enum DataKey {
     CommunityGoal(Address),            // Target flow rate for "Bonus Video"
     UserReferrer(Address),
     ReferralTracker(Address, Address),
-    CurrentFlowRate(Address),   // Aggregated flow rate for a channel
-    AcceptedToken(Address),     // Issue #49: Creator's enforced stablecoin token
-    DaoGrant(Address, Address), // (dao, creator) — DAO treasury grant stream
+    CurrentFlowRate(Address),          // Aggregated flow rate for a channel
+    AcceptedToken(Address),            // Issue #49: Creator's enforced stablecoin token
+    DaoGrant(Address, Address),        // (dao, creator) — DAO treasury grant stream
+    UserContributed(Address, Address), // (fan, creator) — lifetime tokens contributed by fan
 }
 
 #[contracttype]
@@ -283,6 +284,16 @@ pub struct GrantRevoked {
     pub refund_amount: i128,
 }
 
+#[contractevent]
+pub struct CliffUnlocked {
+    #[topic]
+    pub fan: Address,
+    #[topic]
+    pub creator: Address,
+    pub total_contributed: i128,
+    pub cliff_threshold: i128,
+}
+
 #[contract]
 pub struct SubStreamContract;
 
@@ -471,6 +482,7 @@ impl SubStreamContract {
         }
         let token_client = TokenClient::new(&env, &token);
         token_client.transfer(&user, &creator, &amount);
+        credit_fan_contribution(&env, &user, &creator, amount);
         TipReceived {
             user,
             creator,
@@ -625,6 +637,50 @@ impl SubStreamContract {
     }
 
     // -----------------------------------------------------------------------
+    // Cliff-Based Access — Milestone Rewards for Early Supporters
+    // -----------------------------------------------------------------------
+
+    /// Creator sets the lifetime-contribution threshold that unlocks premium content.
+    /// `threshold` is in whole token units (not nano).
+    pub fn set_cliff_threshold(env: Env, creator: Address, threshold: i128) {
+        creator.require_auth();
+        if threshold <= 0 {
+            panic!("threshold must be positive");
+        }
+        env.storage()
+            .persistent()
+            .set(&DataKey::CliffThreshold(creator), &threshold);
+    }
+
+    /// Returns `true` when the fan's lifetime contributions to this creator
+    /// meet or exceed the creator's configured cliff threshold.
+    /// Returns `false` if no threshold is set (feature not enabled by creator).
+    pub fn check_cliff_access(env: Env, fan: Address, creator: Address) -> bool {
+        let threshold: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::CliffThreshold(creator.clone()))
+            .unwrap_or(0);
+        if threshold == 0 {
+            return false;
+        }
+        let contributed: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::UserContributed(fan, creator))
+            .unwrap_or(0);
+        contributed >= threshold
+    }
+
+    /// Returns the fan's total lifetime token contributions to a creator.
+    pub fn get_total_contributed(env: Env, fan: Address, creator: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::UserContributed(fan, creator))
+            .unwrap_or(0)
+    }
+
+    // -----------------------------------------------------------------------
     // DAO Treasury Streaming — Grant Support
     // -----------------------------------------------------------------------
 
@@ -720,6 +776,7 @@ impl SubStreamContract {
             let token_client = TokenClient::new(&env, &grant.token);
             token_client.transfer(&env.current_contract_address(), &creator, &actual_payout);
             credit_creator_earnings(&env, &creator, actual_payout);
+            credit_fan_contribution(&env, &grant.dao, &creator, actual_payout);
         }
 
         grant.balance -= (elapsed.saturating_mul(grant.rate_per_second)).min(grant.balance);
@@ -910,6 +967,37 @@ fn credit_creator_earnings(env: &Env, creator: &Address, amount: i128) {
     set_creator_stats(env, creator, &stats);
 }
 
+/// Increments the fan's lifetime contribution counter for a creator and emits
+/// a `CliffUnlocked` event the first time the threshold is crossed.
+fn credit_fan_contribution(env: &Env, fan: &Address, creator: &Address, amount: i128) {
+    if amount <= 0 {
+        return;
+    }
+    let key = DataKey::UserContributed(fan.clone(), creator.clone());
+    let prev: i128 = env.storage().persistent().get(&key).unwrap_or(0);
+    let next = prev.saturating_add(amount);
+    env.storage().persistent().set(&key, &next);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, TTL_THRESHOLD, TTL_BUMP_AMOUNT);
+
+    // Emit CliffUnlocked exactly once — when the fan crosses the threshold.
+    let threshold: i128 = env
+        .storage()
+        .persistent()
+        .get(&DataKey::CliffThreshold(creator.clone()))
+        .unwrap_or(0);
+    if threshold > 0 && prev < threshold && next >= threshold {
+        CliffUnlocked {
+            fan: fan.clone(),
+            creator: creator.clone(),
+            total_contributed: next,
+            cliff_threshold: threshold,
+        }
+        .publish(env);
+    }
+}
+
 fn distribute_and_collect(
     env: &Env,
     beneficiary: &Address,
@@ -1017,6 +1105,7 @@ fn distribute_and_collect(
             remaining -= payout;
             if payout > 0 {
                 credit_creator_earnings(env, &creator, payout);
+                credit_fan_contribution(env, &sub.beneficiary, &creator, payout);
                 token_client.transfer(&env.current_contract_address(), &creator, &payout);
             }
         }
@@ -1281,6 +1370,8 @@ fn pay_referral_rebate(
 
 #[cfg(test)]
 mod test;
+#[cfg(test)]
+mod test_cliff_access;
 #[cfg(test)]
 mod test_dao_treasury;
 #[cfg(test)]

--- a/contracts/substream_contracts/src/test_cliff_access.rs
+++ b/contracts/substream_contracts/src/test_cliff_access.rs
@@ -1,0 +1,258 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{
+    testutils::{Address as _, Events as _, Ledger},
+    token, Address, Env,
+};
+
+const DAY: u64 = 24 * 60 * 60;
+const WEEK: u64 = 7 * DAY;
+
+fn setup() -> (
+    Env,
+    SubStreamContractClient<'static>,
+    token::Client<'static>,
+    Address, // fan
+    Address, // creator
+) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let sac = env.register_stellar_asset_contract_v2(admin.clone());
+    let token = token::Client::new(&env, &sac.address());
+    let token_admin = token::StellarAssetClient::new(&env, &sac.address());
+
+    let fan = Address::generate(&env);
+    let creator = Address::generate(&env);
+    token_admin.mint(&fan, &1_000_000);
+
+    let contract_id = env.register(SubStreamContract, ());
+    let client = SubStreamContractClient::new(&env, &contract_id);
+    client.initialize(&admin);
+
+    let client: SubStreamContractClient<'static> = unsafe { core::mem::transmute(client) };
+    let token: token::Client<'static> = unsafe { core::mem::transmute(token) };
+
+    (env, client, token, fan, creator)
+}
+
+// ---------------------------------------------------------------------------
+// set_cliff_threshold — basic
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_set_cliff_threshold_stores_value() {
+    let (env, client, _token, _fan, creator) = setup();
+    client.set_cliff_threshold(&creator, &500);
+    // No panic = stored. Verified via check_cliff_access below.
+    let _ = env; // suppress unused warning
+}
+
+#[test]
+#[should_panic(expected = "threshold must be positive")]
+fn test_set_cliff_threshold_zero_panics() {
+    let (_env, client, _token, _fan, creator) = setup();
+    client.set_cliff_threshold(&creator, &0);
+}
+
+// ---------------------------------------------------------------------------
+// check_cliff_access — no threshold set → always false
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_check_cliff_access_no_threshold_returns_false() {
+    let (_env, client, _token, fan, creator) = setup();
+    assert!(!client.check_cliff_access(&fan, &creator));
+}
+
+// ---------------------------------------------------------------------------
+// get_total_contributed — zero before any payment
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_get_total_contributed_zero_initially() {
+    let (_env, client, _token, fan, creator) = setup();
+    assert_eq!(client.get_total_contributed(&fan, &creator), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Tip credits contribution and unlocks cliff
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_tip_credits_contribution() {
+    let (env, client, token, fan, creator) = setup();
+    env.ledger().set_timestamp(0);
+
+    client.tip(&fan, &creator, &token.address, &200);
+    assert_eq!(client.get_total_contributed(&fan, &creator), 200);
+}
+
+#[test]
+fn test_cliff_not_unlocked_below_threshold() {
+    let (env, client, token, fan, creator) = setup();
+    env.ledger().set_timestamp(0);
+
+    client.set_cliff_threshold(&creator, &500);
+    client.tip(&fan, &creator, &token.address, &300);
+
+    assert!(!client.check_cliff_access(&fan, &creator));
+}
+
+#[test]
+fn test_cliff_unlocked_at_threshold() {
+    let (env, client, token, fan, creator) = setup();
+    env.ledger().set_timestamp(0);
+
+    client.set_cliff_threshold(&creator, &500);
+    client.tip(&fan, &creator, &token.address, &500);
+
+    assert!(client.check_cliff_access(&fan, &creator));
+}
+
+#[test]
+fn test_cliff_unlocked_above_threshold() {
+    let (env, client, token, fan, creator) = setup();
+    env.ledger().set_timestamp(0);
+
+    client.set_cliff_threshold(&creator, &100);
+    client.tip(&fan, &creator, &token.address, &300);
+
+    assert!(client.check_cliff_access(&fan, &creator));
+}
+
+// ---------------------------------------------------------------------------
+// CliffUnlocked event emitted exactly once
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_cliff_unlocked_event_emitted_on_crossing() {
+    let (env, client, token, fan, creator) = setup();
+    env.ledger().set_timestamp(0);
+
+    client.set_cliff_threshold(&creator, &500);
+
+    // First tip: below threshold — transfer + TipReceived (2 events)
+    client.tip(&fan, &creator, &token.address, &300);
+    let events_below = env.events().all().events().len();
+
+    // Second tip: crosses threshold — transfer + TipReceived + CliffUnlocked (3 events)
+    client.tip(&fan, &creator, &token.address, &200);
+    let events_crossing = env.events().all().events().len();
+
+    assert_eq!(events_below, 2, "transfer + TipReceived before crossing");
+    assert_eq!(
+        events_crossing, 3,
+        "transfer + TipReceived + CliffUnlocked on crossing"
+    );
+}
+
+#[test]
+fn test_cliff_unlocked_event_not_emitted_again_after_crossing() {
+    let (env, client, token, fan, creator) = setup();
+    env.ledger().set_timestamp(0);
+
+    client.set_cliff_threshold(&creator, &100);
+
+    // Cross the threshold
+    client.tip(&fan, &creator, &token.address, &200);
+
+    // Subsequent tip — transfer + TipReceived only, no CliffUnlocked (2 events)
+    client.tip(&fan, &creator, &token.address, &100);
+    let events = env.events().all().events().len();
+    assert_eq!(
+        events, 2,
+        "CliffUnlocked must not fire again after threshold already crossed"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Streaming subscription credits contribution
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_subscription_stream_credits_contribution() {
+    let (env, client, token, fan, creator) = setup();
+
+    env.ledger().set_timestamp(0);
+    // rate = 1 token/sec; deposit 10_000 tokens
+    client.subscribe(
+        &fan,
+        &creator,
+        &token.address,
+        &10_000,
+        &1_000_000_000,
+        &None,
+    );
+
+    // Advance past trial + 100 paid seconds
+    env.ledger().set_timestamp(WEEK + 100);
+    client.collect(&fan, &creator);
+
+    // Fan should have 100 tokens credited
+    assert_eq!(client.get_total_contributed(&fan, &creator), 100);
+}
+
+#[test]
+fn test_subscription_stream_unlocks_cliff() {
+    let (env, client, token, fan, creator) = setup();
+
+    client.set_cliff_threshold(&creator, &50);
+
+    env.ledger().set_timestamp(0);
+    client.subscribe(
+        &fan,
+        &creator,
+        &token.address,
+        &10_000,
+        &1_000_000_000,
+        &None,
+    );
+
+    // Advance past trial + 60 paid seconds → 60 tokens streamed
+    env.ledger().set_timestamp(WEEK + 60);
+    client.collect(&fan, &creator);
+
+    assert!(client.check_cliff_access(&fan, &creator));
+}
+
+// ---------------------------------------------------------------------------
+// Contributions are per-creator (fan A's total for creator X ≠ creator Y)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_contributions_are_per_creator() {
+    let (env, client, token, fan, creator) = setup();
+    let creator2 = Address::generate(&env);
+    env.ledger().set_timestamp(0);
+
+    client.set_cliff_threshold(&creator, &500);
+    client.set_cliff_threshold(&creator2, &500);
+
+    client.tip(&fan, &creator, &token.address, &500);
+
+    assert!(client.check_cliff_access(&fan, &creator));
+    assert!(!client.check_cliff_access(&fan, &creator2));
+}
+
+// ---------------------------------------------------------------------------
+// Cumulative tips across multiple transactions
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_cumulative_tips_accumulate() {
+    let (env, client, token, fan, creator) = setup();
+    env.ledger().set_timestamp(0);
+
+    client.set_cliff_threshold(&creator, &300);
+
+    client.tip(&fan, &creator, &token.address, &100);
+    client.tip(&fan, &creator, &token.address, &100);
+    assert!(!client.check_cliff_access(&fan, &creator));
+
+    client.tip(&fan, &creator, &token.address, &100);
+    assert!(client.check_cliff_access(&fan, &creator));
+    assert_eq!(client.get_total_contributed(&fan, &creator), 300);
+}


### PR DESCRIPTION
## feat: Implement Cliff-Based Access for Early Supporters

Closes: #52 
Labels: backend smart-contract gamification
Branch: feature/cliff-based-access-early-supporters


### Summary

Moves the protocol beyond simple per-second access into milestone-based rewards. Creators can now set a lifetime 
contribution threshold (cliff) — fans who have streamed or tipped at least that amount receive an "Authorized" 
status, unlocking premium content (e.g., a "Behind the Scenes" video after $100 total contributions). Mirrors top-
tier Patreon reward mechanics on-chain.


### New Contract Functions

| Function | Auth | Description |
|---|---|---|
| set_cliff_threshold(creator, threshold) | Creator | Sets the token milestone in whole units. Feature is opt-in —
no threshold means no gating. |
| check_cliff_access(fan, creator) → bool | None | Returns true when fan's lifetime contributions ≥ threshold. 
Returns false if no threshold is set. |
| get_total_contributed(fan, creator) → i128 | None | Read-only view of a fan's cumulative lifetime contributions 
to a creator. |

### New Storage Key

- DataKey::UserContributed(fan, creator) — persistent i128 counter tracking lifetime tokens paid by a fan to a 
creator. (DataKey::CliffThreshold was already reserved in the enum; now fully wired up.)

### New Event

- CliffUnlocked { fan, creator, total_contributed, cliff_threshold } — emitted exactly once when a fan's cumulative
contributions first meet or exceed the creator's threshold.


### Contribution Tracking

Contributions are credited in every path where tokens genuinely flow from a fan to a creator:

- distribute_and_collect — streaming subscription payouts
- tip — one-off tips
- collect_grant — DAO treasury grant payouts (DAO counted as fan)

Early-cancel penalties are intentionally excluded — they are protocol enforcement, not voluntary support.


### Tests (14 new — test_cliff_access.rs)

- test_set_cliff_threshold_stores_value
- test_set_cliff_threshold_zero_panics
- test_check_cliff_access_no_threshold_returns_false
- test_get_total_contributed_zero_initially
- test_tip_credits_contribution
- test_cliff_not_unlocked_below_threshold
- test_cliff_unlocked_at_threshold
- test_cliff_unlocked_above_threshold
- test_cliff_unlocked_event_emitted_on_crossing
- test_cliff_unlocked_event_not_emitted_again_after_crossing
- test_subscription_stream_credits_contribution
- test_subscription_stream_unlocks_cliff
- test_contributions_are_per_creator
- test_cumulative_tips_accumulate

54/54 tests pass. cargo fmt + cargo clippy -D warnings clean.