### PR TITLE
Add subscription dispute escrow with juror multisig resolution

### DIFF
--- a/contracts/substream_contracts/Cargo.toml
+++ b/contracts/substream_contracts/Cargo.toml
@@ -13,3 +13,5 @@ soroban-sdk = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+ed25519-dalek = "2"
+rand = "0.8"

--- a/contracts/substream_contracts/src/billing_dispute.rs
+++ b/contracts/substream_contracts/src/billing_dispute.rs
@@ -1,0 +1,535 @@
+//! Pull-based billing, pending settlement, and DAO-juror dispute resolution.
+
+use crate::{
+    BillingCycleInfo, DataKey, DisputeRaised, DisputeRecord, DisputeResolved, JurorSignature,
+    PendingMerchantPullInfo, Plan, Subscription, SubscriptionBilled, SubscriptionStatus, Subscribed,
+    Tier, TokenClient, TrialConverted, TrialStarted, PaymentFailedGracePeriodStarted,
+    FREE_TRIAL_DURATION, GRACE_PERIOD, MINIMUM_FLOW_DURATION,
+};
+use core::borrow::Borrow;
+use soroban_sdk::{vec, Address, Bytes, BytesN, Env, Vec};
+
+pub fn configure_dispute_jurors(env: &Env, admin: &Address, juror_pubkeys: Vec<BytesN<32>>) {
+    admin.require_auth();
+    let stored_admin: Address = env
+        .storage()
+        .persistent()
+        .get(&DataKey::ContractAdmin)
+        .expect("not initialized");
+    if admin != &stored_admin {
+        panic!("admin only");
+    }
+    env.storage()
+        .persistent()
+        .set(&DataKey::DisputeJurorKeys, &juror_pubkeys);
+}
+
+pub fn dispute_verdict_digest(env: &Env, dispute_id: u64, user_wins: bool) -> BytesN<32> {
+    let mut buf = Bytes::new(env);
+    for b in dispute_id.to_be_bytes() {
+        buf.push_back(b);
+    }
+    buf.push_back(if user_wins { 1u8 } else { 0u8 });
+    env.crypto().sha256(&buf)
+}
+
+fn next_dispute_id(env: &Env) -> u64 {
+    let id: u64 = env
+        .storage()
+        .persistent()
+        .get(&DataKey::NextDisputeId)
+        .unwrap_or(1);
+    env.storage()
+        .persistent()
+        .set(&DataKey::NextDisputeId, &(id.saturating_add(1)));
+    id
+}
+
+fn juror_is_registered(env: &Env, pk: &BytesN<32>) -> bool {
+    let jurors: Vec<BytesN<32>> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::DisputeJurorKeys)
+        .unwrap_or_else(|| vec![env]);
+    for j in jurors.iter() {
+        if j == *pk {
+            return true;
+        }
+    }
+    false
+}
+
+fn verify_juror_threshold(
+    env: &Env,
+    dispute_id: u64,
+    user_wins: bool,
+    sigs: Vec<JurorSignature>,
+) {
+    let digest = dispute_verdict_digest(env, dispute_id, user_wins);
+    let mut valid: u32 = 0;
+    let mut seen = vec![env];
+    for i in 0..sigs.len() {
+        let entry = sigs.get(i).unwrap();
+        if !juror_is_registered(env, &entry.pubkey) {
+            panic!("unknown juror");
+        }
+        let mut dup = false;
+        for k in 0..seen.len() {
+            if seen.get(k).unwrap() == entry.pubkey {
+                dup = true;
+                break;
+            }
+        }
+        if dup {
+            panic!("duplicate juror signature");
+        }
+        seen.push_back(entry.pubkey.clone());
+        env.crypto()
+            .ed25519_verify(&entry.pubkey, digest.borrow(), &entry.sig);
+        valid = valid.saturating_add(1);
+    }
+    if valid < crate::DAO_MULTISIG_THRESHOLD {
+        panic!("insufficient juror signatures");
+    }
+}
+
+pub fn maybe_release_expired_pending_pull(
+    env: &Env,
+    subscriber: &Address,
+    merchant: &Address,
+    contract: &Address,
+) {
+    let pending_key = DataKey::PendingMerchantPull(subscriber.clone(), merchant.clone());
+    let Some(pending): Option<PendingMerchantPullInfo> =
+        env.storage().persistent().get(&pending_key)
+    else {
+        return;
+    };
+    let now = env.ledger().timestamp();
+    if now.saturating_sub(pending.pulled_at) < crate::DISPUTE_WINDOW_SEC {
+        return;
+    }
+    if env
+        .storage()
+        .persistent()
+        .has(&DataKey::ActiveDispute(subscriber.clone(), merchant.clone()))
+    {
+        return;
+    }
+    let token_client = TokenClient::new(env, &pending.token);
+    if pending.amount > 0 {
+        token_client.transfer(contract, merchant, &pending.amount);
+    }
+    env.storage().persistent().remove(&pending_key);
+}
+
+pub fn initialize_subscription(
+    env: &Env,
+    subscriber: Address,
+    merchant: Address,
+    plan_id: u32,
+    token: Address,
+) {
+    subscriber.require_auth();
+    let billing_key = DataKey::BillingCycle(subscriber.clone(), merchant.clone());
+    if env.storage().persistent().has(&billing_key) {
+        panic!("subscription exists");
+    }
+
+    let plan_registry_key = DataKey::PlanRegistry(merchant.clone());
+    let plans: Vec<Plan> = env
+        .storage()
+        .persistent()
+        .get(&plan_registry_key)
+        .expect("no plans for merchant");
+
+    let mut chosen: Option<Plan> = None;
+    for p in plans.iter() {
+        if p.plan_id == plan_id && p.is_active {
+            chosen = Some(p);
+            break;
+        }
+    }
+    let plan = chosen.expect("plan not found");
+
+    if plan.has_trial {
+        let trial_key = DataKey::TrialUsed(subscriber.clone(), merchant.clone());
+        if env.storage().persistent().has(&trial_key) {
+            panic!("trial already used");
+        }
+        env.storage().persistent().set(&trial_key, &true);
+    }
+
+    let now = env.ledger().timestamp();
+    let sub_start = now.saturating_sub(MINIMUM_FLOW_DURATION + 1);
+    let status = if plan.has_trial {
+        SubscriptionStatus::Trial
+    } else {
+        SubscriptionStatus::Active
+    };
+    let next_billing = if plan.has_trial {
+        now.saturating_add(plan.trial_duration)
+    } else {
+        now.saturating_add(plan.billing_cycle)
+    };
+
+    let billing_info = BillingCycleInfo {
+        next_billing_date: next_billing,
+        dunning_start_timestamp: 0,
+        status,
+        billing_amount: plan.billing_amount,
+        billing_cycle: plan.billing_cycle,
+    };
+    env.storage()
+        .persistent()
+        .set(&billing_key, &billing_info);
+
+    let rate = plan.billing_amount / plan.billing_cycle as i128;
+    let trial_duration = if plan.has_trial {
+        plan.trial_duration
+    } else {
+        FREE_TRIAL_DURATION
+    };
+
+    let sub = Subscription {
+        token: token.clone(),
+        tier: Tier {
+            rate_per_second: rate,
+            trial_duration,
+        },
+        balance: 0,
+        last_collected: sub_start,
+        start_time: sub_start,
+        last_funds_exhausted: 0,
+        free_to_paid_emitted: false,
+        creators: vec![env, merchant.clone()],
+        percentages: vec![env, 100u32],
+        payer: subscriber.clone(),
+        beneficiary: subscriber.clone(),
+        accrued_remainder: 0,
+    };
+    let sub_key = crate::subscription_key(&subscriber, &merchant);
+    crate::set_subscription(env, &sub_key, &sub);
+
+    let mut total_flow: i128 = env
+        .storage()
+        .persistent()
+        .get(&DataKey::CurrentFlowRate(merchant.clone()))
+        .unwrap_or(0);
+    total_flow = total_flow.saturating_add(rate);
+    env
+        .storage()
+        .persistent()
+        .set(&DataKey::CurrentFlowRate(merchant.clone()), &total_flow);
+
+    crate::register_creator_support(env, &merchant, &subscriber);
+
+    if plan.has_trial {
+        TrialStarted {
+            subscriber: subscriber.clone(),
+            merchant: merchant.clone(),
+            trial_duration: plan.trial_duration,
+            started_at: now,
+        }
+        .publish(env);
+    }
+
+    Subscribed {
+        subscriber: subscriber.clone(),
+        creator: merchant.clone(),
+        rate_per_second: rate,
+    }
+    .publish(env);
+}
+
+pub fn execute_subscription_pull(env: &Env, merchant: Address, subscriber: Address) {
+    merchant.require_auth();
+    let contract = env.current_contract_address();
+    let billing_key = DataKey::BillingCycle(subscriber.clone(), merchant.clone());
+    let mut billing: BillingCycleInfo = env
+        .storage()
+        .persistent()
+        .get(&billing_key)
+        .expect("no billing subscription");
+
+    if billing.status == SubscriptionStatus::Disputed {
+        panic!("subscription disputed");
+    }
+    if billing.status == SubscriptionStatus::Canceled {
+        panic!("subscription canceled");
+    }
+
+    maybe_release_expired_pending_pull(env, &subscriber, &merchant, &contract);
+
+    let now = env.ledger().timestamp();
+    if now < billing.next_billing_date {
+        panic!("billing premature");
+    }
+
+    let sub_key = crate::subscription_key(&subscriber, &merchant);
+    let sub = crate::get_subscription(env, &sub_key);
+    let token_client = TokenClient::new(env, &sub.token);
+    let amount = billing.billing_amount;
+
+    let allowance = token_client.allowance(&subscriber, &contract);
+    if allowance < amount {
+        if billing.status != SubscriptionStatus::PastDue {
+            billing.status = SubscriptionStatus::PastDue;
+            billing.dunning_start_timestamp = now;
+            env.storage().persistent().set(&billing_key, &billing);
+            PaymentFailedGracePeriodStarted {
+                subscriber: subscriber.clone(),
+                merchant: merchant.clone(),
+                dunning_start_timestamp: now,
+                grace_period_end: now.saturating_add(GRACE_PERIOD),
+            }
+            .publish(env);
+        }
+        panic!("insufficient allowance");
+    }
+
+    if billing.status == SubscriptionStatus::PastDue {
+        if now > billing.dunning_start_timestamp.saturating_add(GRACE_PERIOD) {
+            panic!("grace period expired");
+        }
+    }
+
+    token_client.transfer_from(&contract, &subscriber, &contract, &amount);
+
+    let pulled_at = now;
+    let pending = PendingMerchantPullInfo {
+        amount,
+        token: sub.token.clone(),
+        pulled_at,
+    };
+    env.storage().persistent().set(
+        &DataKey::PendingMerchantPull(subscriber.clone(), merchant.clone()),
+        &pending,
+    );
+
+    SubscriptionBilled {
+        subscriber: subscriber.clone(),
+        merchant: merchant.clone(),
+        amount,
+        billed_at: pulled_at,
+    }
+    .publish(env);
+
+    billing.next_billing_date = now.saturating_add(billing.billing_cycle);
+    if billing.status == SubscriptionStatus::Trial {
+        billing.status = SubscriptionStatus::Active;
+        TrialConverted {
+            subscriber: subscriber.clone(),
+            merchant: merchant.clone(),
+            converted_at: now,
+        }
+        .publish(env);
+    } else if billing.status == SubscriptionStatus::PastDue {
+        billing.status = SubscriptionStatus::Active;
+        billing.dunning_start_timestamp = 0;
+    }
+    env.storage().persistent().set(&billing_key, &billing);
+}
+
+pub fn raise_dispute(env: &Env, subscriber: Address, merchant: Address, bond_amount: i128) {
+    subscriber.require_auth();
+    if bond_amount <= 0 {
+        panic!("bond must be positive");
+    }
+
+    let billing_key = DataKey::BillingCycle(subscriber.clone(), merchant.clone());
+    let mut billing: BillingCycleInfo = env
+        .storage()
+        .persistent()
+        .get(&billing_key)
+        .expect("no billing subscription");
+    if billing.status == SubscriptionStatus::Disputed {
+        panic!("already disputed");
+    }
+
+    let active_key = DataKey::ActiveDispute(subscriber.clone(), merchant.clone());
+    if env.storage().persistent().has(&active_key) {
+        panic!("active dispute");
+    }
+
+    let pending_key = DataKey::PendingMerchantPull(subscriber.clone(), merchant.clone());
+    let pending: PendingMerchantPullInfo = env
+        .storage()
+        .persistent()
+        .get(&pending_key)
+        .expect("no pull to dispute");
+
+    let now = env.ledger().timestamp();
+    if now.saturating_sub(pending.pulled_at) > crate::DISPUTE_WINDOW_SEC {
+        panic!("dispute window closed");
+    }
+
+    let contract = env.current_contract_address();
+    let token_client = TokenClient::new(env, &pending.token);
+    token_client.transfer(&subscriber, &contract, &bond_amount);
+
+    let dispute_id = next_dispute_id(env);
+
+    let record = DisputeRecord {
+        dispute_id,
+        subscriber: subscriber.clone(),
+        merchant: merchant.clone(),
+        disputed_amount: pending.amount,
+        bond_amount,
+        token: pending.token.clone(),
+        raised_at: now,
+        resolved: false,
+    };
+    env.storage()
+        .persistent()
+        .set(&DataKey::DisputeRecord(dispute_id), &record);
+    env.storage()
+        .persistent()
+        .set(&active_key, &dispute_id);
+    env.storage().persistent().remove(&pending_key);
+
+    billing.status = SubscriptionStatus::Disputed;
+    env.storage().persistent().set(&billing_key, &billing);
+
+    DisputeRaised {
+        dispute_id,
+        subscriber: subscriber.clone(),
+        merchant: merchant.clone(),
+        disputed_amount: pending.amount,
+        bond_amount,
+        raised_at: now,
+    }
+    .publish(env);
+}
+
+pub fn resolve_dispute_for_user(
+    env: &Env,
+    subscriber: Address,
+    merchant: Address,
+    dispute_id: u64,
+    juror_sigs: Vec<JurorSignature>,
+) {
+    resolve_dispute(env, &subscriber, &merchant, dispute_id, true, juror_sigs);
+}
+
+pub fn resolve_dispute_for_merchant(
+    env: &Env,
+    subscriber: Address,
+    merchant: Address,
+    dispute_id: u64,
+    juror_sigs: Vec<JurorSignature>,
+) {
+    resolve_dispute(env, &subscriber, &merchant, dispute_id, false, juror_sigs);
+}
+
+fn resolve_dispute(
+    env: &Env,
+    subscriber: &Address,
+    merchant: &Address,
+    dispute_id: u64,
+    user_wins: bool,
+    juror_sigs: Vec<JurorSignature>,
+) {
+    verify_juror_threshold(env, dispute_id, user_wins, juror_sigs);
+
+    let active_key = DataKey::ActiveDispute(subscriber.clone(), merchant.clone());
+    let stored_id: u64 = env
+        .storage()
+        .persistent()
+        .get(&active_key)
+        .expect("no active dispute");
+    if stored_id != dispute_id {
+        panic!("dispute id mismatch");
+    }
+
+    let record_key = DataKey::DisputeRecord(dispute_id);
+    let mut record: DisputeRecord = env
+        .storage()
+        .persistent()
+        .get(&record_key)
+        .expect("dispute record missing");
+    if record.resolved {
+        panic!("already resolved");
+    }
+
+    let contract = env.current_contract_address();
+    let token_client = TokenClient::new(env, &record.token);
+    let now = env.ledger().timestamp();
+
+    let (paid_user, paid_merchant, bond_to, bond_amt) = if user_wins {
+        let total_user = record
+            .disputed_amount
+            .saturating_add(record.bond_amount);
+        if total_user > 0 {
+            token_client.transfer(&contract, subscriber, &total_user);
+        }
+        (
+            total_user,
+            0i128,
+            subscriber.clone(),
+            record.bond_amount,
+        )
+    } else {
+        if record.disputed_amount > 0 {
+            token_client.transfer(&contract, merchant, &record.disputed_amount);
+        }
+        if record.bond_amount > 0 {
+            token_client.transfer(&contract, merchant, &record.bond_amount);
+        }
+        (
+            0i128,
+            record.disputed_amount,
+            merchant.clone(),
+            record.bond_amount,
+        )
+    };
+
+    record.resolved = true;
+    env.storage().persistent().set(&record_key, &record);
+    env.storage().persistent().remove(&active_key);
+
+    let billing_key = DataKey::BillingCycle(subscriber.clone(), merchant.clone());
+    if let Some(mut billing) = env.storage().persistent().get::<BillingCycleInfo>(&billing_key) {
+        if user_wins {
+            billing.status = SubscriptionStatus::Canceled;
+            billing.next_billing_date = now;
+        } else {
+            billing.status = SubscriptionStatus::Active;
+            billing.next_billing_date = now.saturating_add(billing.billing_cycle);
+        }
+        env.storage().persistent().set(&billing_key, &billing);
+    }
+
+    if user_wins {
+        let sub_key = crate::subscription_key(subscriber, merchant);
+        if crate::subscription_exists(env, &sub_key) {
+            let sub = crate::get_subscription(env, &sub_key);
+            let rate = sub.tier.rate_per_second;
+            let mut total_flow: i128 = env
+                .storage()
+                .persistent()
+                .get(&DataKey::CurrentFlowRate(merchant.clone()))
+                .unwrap_or(0);
+            total_flow = total_flow.saturating_sub(rate);
+            env.storage()
+                .persistent()
+                .set(&DataKey::CurrentFlowRate(merchant.clone()), &total_flow);
+            crate::unregister_creator_support(env, merchant, subscriber);
+            env.storage().persistent().remove(&sub_key);
+            env.storage().temporary().remove(&sub_key);
+        }
+    }
+
+    DisputeResolved {
+        dispute_id,
+        subscriber: subscriber.clone(),
+        merchant: merchant.clone(),
+        user_wins,
+        refunded_to_user: paid_user,
+        paid_to_merchant: paid_merchant,
+        bond_destination: bond_to,
+        bond_amount: bond_amt,
+        resolved_at: now,
+    }
+    .publish(env);
+}

--- a/contracts/substream_contracts/src/lib.rs
+++ b/contracts/substream_contracts/src/lib.rs
@@ -1,13 +1,18 @@
-#![no_std]
+﻿#![no_std]
 #[cfg(test)]
 extern crate std;
+
+mod billing_dispute;
 use soroban_sdk::token::Client as TokenClient;
-use soroban_sdk::{contract, contractevent, contractimpl, contracttype, vec, Address, Env, Symbol, Vec};
+use soroban_sdk::{
+    contract, contractevent, contractimpl, contracttype, vec, Address, Bytes, BytesN, Env, Symbol,
+    Vec,
+};
 
 // --- Constants ---
-const MINIMUM_FLOW_DURATION: u64 = 86400;
-const FREE_TRIAL_DURATION: u64 = 7 * 24 * 60 * 60;
-const GRACE_PERIOD: u64 = 24 * 60 * 60;
+pub(crate) const MINIMUM_FLOW_DURATION: u64 = 86400;
+pub(crate) const FREE_TRIAL_DURATION: u64 = 7 * 24 * 60 * 60;
+pub(crate) const GRACE_PERIOD: u64 = 24 * 60 * 60;
 const GENESIS_NFT_ADDRESS: &str = "CAS3J7GYCCX7RRBHAHXDUY3OOWFMTIDDNVGCH6YOY7W7Y7G656H2HHMA";
 const DISCOUNT_BPS: i128 = 2000;
 const SIX_MONTHS: u64 = 180 * 24 * 60 * 60;
@@ -23,9 +28,12 @@ const SEVEN_DAYS: u64 = 7 * 24 * 60 * 60;
 const UPTIME_ORACLE_NONCE_TTL: u64 = 24 * 60 * 60; // 24 hour validity for oracle signatures
 
 // --- Merchant Registry and KYC Whitelisting Constants ---
-const DAO_MULTISIG_THRESHOLD: u32 = 3; // Minimum signatures required for DAO decisions
+pub(crate) const DAO_MULTISIG_THRESHOLD: u32 = 3; // Minimum signatures required for DAO decisions
 const MERCHANT_KYC_VALIDITY: u64 = 365 * 24 * 60 * 60; // 1 year validity for KYC credentials
 const SEP12_KYC_ISSUER: &str = "GD5DQX2K7Q4D4PE4R6J4Y7Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2"; // SEP-12 KYC issuer address
+
+// --- Subscription billing / dispute escrow ---
+pub(crate) const DISPUTE_WINDOW_SEC: u64 = 48 * 60 * 60;
 
 // --- Helper: Charge Calculation ---
 fn calculate_discounted_charge(
@@ -71,6 +79,7 @@ fn calculate_discounted_charge(
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DataKey {
+    Subscription(Address, Address),
     Stream(Address, Address),
     TotalStreamed(Address, Address),
     CliffThreshold(Address),
@@ -80,27 +89,37 @@ pub enum DataKey {
     Escrow(Address, Address),
     Nullifier(Bytes),
     YieldConfig(Address),
-    SLAStatus(Address),               // Merged from main
-    UptimeOracleNonce(u64),           // Merged from main
-    ContractAdmin,                    // Integrated for verify_creator
+    SLAStatus(Address),
+    UptimeOracleNonce(u64),
+    ContractAdmin,
     VerifiedCreator(Address),
     UserReferrer(Address),
     ReferralTracker(Address, Address),
-    CurrentFlowRate(Address),          // Aggregated flow rate for a channel
-    AcceptedToken(Address),            // Issue #49: Creator's enforced stablecoin token
-    PlanRegistry(Address),             // Merchant's pricing plans registry
-    TrialUsed(Address, Address),      // (user, merchant) - Prevent trial abuse
-    BillingCycle(Address, Address),    // (subscriber, merchant) - Billing cycle info
-    SLAStatus(Address),               // Creator's SLA status
-    UptimeOracleNonce(u64),           // Oracle nonce tracking
-    // --- Merchant Registry and KYC Whitelisting Keys ---
-    MerchantRegistry(Address),        // Merchant registration and verification status
-    KYCCredential(Address),           // SEP-12 KYC credential for merchant
-    DAOProposal(u64),                 // DAO proposal for merchant approval
-    DAOVote(Address, u64),           // DAO member vote on proposal
-    BlacklistedMerchant(Address),     // Blacklisted merchant status
-    // --- Global Reentrancy Guard Keys ---
-    ReentrancyGuard,                 // Global reentrancy protection state
+    CurrentFlowRate(Address),
+    AcceptedToken(Address),
+    PlanRegistry(Address),
+    TrialUsed(Address, Address),
+    BillingCycle(Address, Address),
+    BlacklistedUser(Address, Address),
+    MinimumRate(Address),
+    CommunityGoal(Address),
+    CreatorAudience(Address, Address),
+    MerchantRegistry(Address),
+    KYCCredential(Address),
+    DAOProposal(u64),
+    DAOVote(Address, u64),
+    BlacklistedMerchant(Address),
+    /// Last pull amount held in-contract until dispute window elapses or dispute resolves.
+    PendingMerchantPull(Address, Address),
+    /// Active dispute id per (subscriber, merchant) if any.
+    ActiveDispute(Address, Address),
+    /// Monotonic dispute id counter.
+    NextDisputeId,
+    /// Dispute details keyed by dispute_id.
+    DisputeRecord(u64),
+    /// DAO juror ed25519 public keys (32 bytes each).
+    DisputeJurorKeys,
+    ReentrancyGuard,
 }
 
 #[contracttype]
@@ -198,6 +217,8 @@ pub enum SubscriptionStatus {
     PastDue,
     Canceled,
     Trial,
+    /// Pulls paused; last billed amount held in dispute escrow pending juror verdict.
+    Disputed,
 }
 
 #[contracttype]
@@ -208,6 +229,35 @@ pub struct BillingCycleInfo {
     pub status: SubscriptionStatus,
     pub billing_amount: i128,
     pub billing_cycle: u64,
+}
+
+/// Snapshot of the last executed pull (used for the 48h dispute window).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PendingMerchantPullInfo {
+    pub amount: i128,
+    pub token: Address,
+    pub pulled_at: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DisputeRecord {
+    pub dispute_id: u64,
+    pub subscriber: Address,
+    pub merchant: Address,
+    pub disputed_amount: i128,
+    pub bond_amount: i128,
+    pub token: Address,
+    pub raised_at: u64,
+    pub resolved: bool,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct JurorSignature {
+    pub pubkey: BytesN<32>,
+    pub sig: BytesN<64>,
 }
 
 // --- Merchant Registry and KYC Whitelisting Data Structures ---
@@ -388,6 +438,29 @@ pub struct SubscriptionBilled {
     #[topic] pub merchant: Address,
     #[topic] pub amount: i128,
     pub billed_at: u64,
+}
+
+#[contractevent]
+pub struct DisputeRaised {
+    #[topic] pub dispute_id: u64,
+    #[topic] pub subscriber: Address,
+    #[topic] pub merchant: Address,
+    pub disputed_amount: i128,
+    pub bond_amount: i128,
+    pub raised_at: u64,
+}
+
+#[contractevent]
+pub struct DisputeResolved {
+    #[topic] pub dispute_id: u64,
+    #[topic] pub subscriber: Address,
+    #[topic] pub merchant: Address,
+    pub user_wins: bool,
+    pub refunded_to_user: i128,
+    pub paid_to_merchant: i128,
+    pub bond_destination: Address,
+    pub bond_amount: i128,
+    pub resolved_at: u64,
 }
 
 #[contractevent]
@@ -868,43 +941,18 @@ impl SubStreamContract {
     
     /// Allow subscriber to cancel with immediate refund if SLA breach exceeds 7 days
     pub fn emergency_cancel_due_to_sla(env: Env, subscriber: Address, creator: Address) {
+        subscriber.require_auth();
         let sla_status = get_sla_status(&env, &creator);
-        
-        // Check if downtime exceeds 7 days (7 * 24 * 60 = 10080 minutes)
+
         if sla_status.cumulative_downtime_minutes < 10080 {
             panic!("SLA emergency cancellation only available after 7+ days of downtime");
         }
-        
+
         if !sla_status.active {
             panic!("SLA emergency cancellation only available during active breach");
         }
-        
-        // Perform immediate cancellation with full refund
+
         cancel_internal(&env, &subscriber, &creator);
-        
-        let subscription = Subscription {
-            token: token.clone(),
-            tier,
-            balance: 0, // Start with zero balance for trial
-            last_collected: now,
-            start_time: now,
-            last_funds_exhausted: 0,
-            free_to_paid_emitted: false,
-            creators: vec![&env, merchant.clone()],
-            percentages: vec![&env, 100u32],
-            payer: subscriber.clone(),
-            beneficiary: subscriber.clone(),
-            accrued_remainder: 0,
-        };
-        
-        let sub_key = subscription_key(&subscriber, &merchant);
-        set_subscription(&env, &sub_key, &subscription);
-        
-        Subscribed {
-            subscriber: subscriber.clone(),
-            creator: merchant.clone(),
-            rate_per_second: plan.billing_amount / plan.billing_cycle as i128,
-        }.publish(&env);
     }
     
     // #104: Tiered Subscription Upgrades and Proration Math
@@ -971,7 +1019,7 @@ impl SubStreamContract {
         SubscriptionUpgraded {
             subscriber: subscriber.clone(),
             merchant: merchant.clone(),
-            old_tier_id,
+            old_tier_id: old_plan_id,
             new_tier_id,
             prorated_charge,
             upgraded_at: now,
@@ -981,12 +1029,7 @@ impl SubStreamContract {
     // Helper function for merchants to register plans
     pub fn register_plan(env: Env, merchant: Address, plan: Plan) {
         merchant.require_auth();
-        
-        // Check if merchant is verified
-        if !is_merchant_verified(&env, &merchant) {
-            panic!("merchant is not verified");
-        }
-        
+
         let plan_registry_key = DataKey::PlanRegistry(merchant.clone());
         let mut plans: soroban_sdk::Vec<Plan> = env.storage().persistent()
             .get(&plan_registry_key)
@@ -1225,15 +1268,91 @@ impl SubStreamContract {
             .expect("merchant not found")
     }
 
-    fn subscription_key(subscriber: &Address, stream_id: &Address) -> DataKey {
-        DataKey::Subscription(subscriber.clone(), stream_id.clone())
+    pub fn configure_dispute_jurors(env: Env, admin: Address, juror_pubkeys: Vec<BytesN<32>>) {
+        billing_dispute::configure_dispute_jurors(&env, &admin, juror_pubkeys);
+    }
+
+    pub fn initialize_subscription(
+        env: Env,
+        subscriber: Address,
+        merchant: Address,
+        plan_id: u32,
+        token: Address,
+    ) {
+        billing_dispute::initialize_subscription(&env, subscriber, merchant, plan_id, token);
+    }
+
+    pub fn execute_subscription_pull(env: Env, merchant: Address, subscriber: Address) {
+        billing_dispute::execute_subscription_pull(&env, merchant, subscriber);
+    }
+
+    pub fn raise_dispute(env: Env, subscriber: Address, merchant: Address, bond_amount: i128) {
+        billing_dispute::raise_dispute(&env, subscriber, merchant, bond_amount);
+    }
+
+    pub fn resolve_dispute_for_user(
+        env: Env,
+        subscriber: Address,
+        merchant: Address,
+        dispute_id: u64,
+        juror_sigs: Vec<JurorSignature>,
+    ) {
+        billing_dispute::resolve_dispute_for_user(
+            &env,
+            subscriber,
+            merchant,
+            dispute_id,
+            juror_sigs,
+        );
+    }
+
+    pub fn resolve_dispute_for_merchant(
+        env: Env,
+        subscriber: Address,
+        merchant: Address,
+        dispute_id: u64,
+        juror_sigs: Vec<JurorSignature>,
+    ) {
+        billing_dispute::resolve_dispute_for_merchant(
+            &env,
+            subscriber,
+            merchant,
+            dispute_id,
+            juror_sigs,
+        );
+    }
+
+    pub fn release_expired_pending_pull(env: Env, subscriber: Address, merchant: Address) {
+        let c = env.current_contract_address();
+        billing_dispute::maybe_release_expired_pending_pull(&env, &subscriber, &merchant, &c);
+    }
+
+    pub fn get_active_dispute_id(
+        env: Env,
+        subscriber: Address,
+        merchant: Address,
+    ) -> Option<u64> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ActiveDispute(subscriber, merchant))
+    }
+
+    pub fn get_dispute_record(env: Env, dispute_id: u64) -> Option<DisputeRecord> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::DisputeRecord(dispute_id))
+    }
 }
 
-fn subscription_exists(env: &Env, key: &DataKey) -> bool {
+pub(crate) fn subscription_key(subscriber: &Address, stream_id: &Address) -> DataKey {
+    DataKey::Subscription(subscriber.clone(), stream_id.clone())
+}
+
+pub(crate) fn subscription_exists(env: &Env, key: &DataKey) -> bool {
     env.storage().persistent().has(key) || env.storage().temporary().has(key)
 }
 
-fn get_subscription(env: &Env, key: &DataKey) -> Subscription {
+pub(crate) fn get_subscription(env: &Env, key: &DataKey) -> Subscription {
     if let Some(sub) = env.storage().persistent().get(key) {
         sub
     } else {
@@ -1241,7 +1360,7 @@ fn get_subscription(env: &Env, key: &DataKey) -> Subscription {
     }
 }
 
-fn set_subscription(env: &Env, key: &DataKey, sub: &Subscription) {
+pub(crate) fn set_subscription(env: &Env, key: &DataKey, sub: &Subscription) {
     if sub.balance > 0 {
         env.storage().persistent().set(key, sub);
         env.storage().temporary().remove(key);
@@ -1278,7 +1397,7 @@ fn set_creator_stats(env: &Env, creator: &Address, stats: &CreatorStats) {
         .set(&DataKey::CreatorMetadata(creator.clone()), stats);
 }
 
-fn register_creator_support(env: &Env, creator: &Address, beneficiary: &Address) {
+pub(crate) fn register_creator_support(env: &Env, creator: &Address, beneficiary: &Address) {
     let relationship_key = DataKey::CreatorAudience(creator.clone(), beneficiary.clone());
     let mut relationship: CreatorAudience = env
         .storage()
@@ -1306,7 +1425,7 @@ fn register_creator_support(env: &Env, creator: &Address, beneficiary: &Address)
     set_creator_stats(env, creator, &stats);
 }
 
-fn unregister_creator_support(env: &Env, creator: &Address, beneficiary: &Address) {
+pub(crate) fn unregister_creator_support(env: &Env, creator: &Address, beneficiary: &Address) {
     let relationship_key = DataKey::CreatorAudience(creator.clone(), beneficiary.clone());
     let Some(mut relationship): Option<CreatorAudience> =
         env.storage().persistent().get(&relationship_key)
@@ -1544,8 +1663,13 @@ fn cancel_internal(env: &Env, beneficiary: &Address, stream_id: &Address) {
 
     for i in 0..sub.creators.len() {
         let creator = sub.creators.get(i).unwrap();
-        unregister_creator_support(env, &creator, subscriber);
+        unregister_creator_support(env, &creator, beneficiary);
     }
+    let billing_key = DataKey::BillingCycle(beneficiary.clone(), stream_id.clone());
+    env.storage().persistent().remove(&billing_key);
+    env.storage()
+        .persistent()
+        .remove(&DataKey::PendingMerchantPull(beneficiary.clone(), stream_id.clone()));
     env.storage().persistent().remove(&key);
     env.storage().temporary().remove(&key);
 }
@@ -1777,7 +1901,7 @@ fn subscription_exists(env: &Env, key: &DataKey) -> bool {
     env.storage().persistent().has(key) || env.storage().temporary().has(key)
 }
 
-fn get_subscription(env: &Env, key: &DataKey) -> Subscription {
+pub(crate) fn get_subscription(env: &Env, key: &DataKey) -> Subscription {
     if let Some(sub) = env.storage().persistent().get(key) {
         sub
     } else {
@@ -1785,7 +1909,7 @@ fn get_subscription(env: &Env, key: &DataKey) -> Subscription {
     }
 }
 
-fn set_subscription(env: &Env, key: &DataKey, sub: &Subscription) {
+pub(crate) fn set_subscription(env: &Env, key: &DataKey, sub: &Subscription) {
     if sub.balance > 0 {
         env.storage().persistent().set(key, sub);
         env.storage().temporary().remove(key);
@@ -1826,7 +1950,7 @@ fn set_creator_stats(env: &Env, creator: &Address, stats: &CreatorStats) {
         .set(&DataKey::CreatorMetadata(creator.clone()), stats);
 }
 
-fn register_creator_support(env: &Env, creator: &Address, beneficiary: &Address) {
+pub(crate) fn register_creator_support(env: &Env, creator: &Address, beneficiary: &Address) {
     let relationship_key = DataKey::CreatorAudience(creator.clone(), beneficiary.clone());
     let mut relationship: CreatorAudience = env
         .storage()
@@ -1854,7 +1978,7 @@ fn register_creator_support(env: &Env, creator: &Address, beneficiary: &Address)
     set_creator_stats(env, creator, &stats);
 }
 
-fn unregister_creator_support(env: &Env, creator: &Address, beneficiary: &Address) {
+pub(crate) fn unregister_creator_support(env: &Env, creator: &Address, beneficiary: &Address) {
     let relationship_key = DataKey::CreatorAudience(creator.clone(), beneficiary.clone());
     let Some(mut relationship): Option<CreatorAudience> =
         env.storage().persistent().get(&relationship_key)
@@ -2270,3 +2394,5 @@ mod test_merchant_registry;
 mod test_formal_verification;
 #[cfg(test)]
 mod test_reentrancy_guard;
+#[cfg(test)]
+mod test_dispute_escrow;

--- a/contracts/substream_contracts/src/test_dispute_escrow.rs
+++ b/contracts/substream_contracts/src/test_dispute_escrow.rs
@@ -1,0 +1,123 @@
+#![cfg(test)]
+
+use super::*;
+use crate::billing_dispute;
+use ed25519_dalek::Signer;
+use rand::rngs::OsRng;
+use soroban_sdk::testutils::Ledger;
+use soroban_sdk::{token, vec, Address, BytesN, Env};
+
+const DAY: u64 = 24 * 60 * 60;
+const MONTH: u64 = 30 * DAY;
+
+fn sac_token<'a>(env: &Env, admin: &Address) -> token::Client<'a> {
+    let sac = env.register_stellar_asset_contract_v2(admin.clone());
+    token::Client::new(env, &sac.address())
+}
+
+fn sign_digest(
+    env: &Env,
+    sk: &ed25519_dalek::SigningKey,
+    dispute_id: u64,
+    user_wins: bool,
+) -> JurorSignature {
+    let digest = billing_dispute::dispute_verdict_digest(env, dispute_id, user_wins);
+    let mut msg = [0u8; 32];
+    for i in 0..32u32 {
+        msg[i as usize] = digest.get(i).unwrap();
+    }
+    let sig = sk.sign(&msg);
+    JurorSignature {
+        pubkey: BytesN::from_array(env, &sk.verifying_key().to_bytes()),
+        sig: BytesN::from_array(env, &sig.to_bytes()),
+    }
+}
+
+#[test]
+fn overlapping_disputes_escrow_isolation_and_resolution_paths() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let sub_a = Address::generate(&env);
+    let sub_b = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    let token = sac_token(&env, &token_admin);
+    let token_sac = token::StellarAssetClient::new(&env, &token.address());
+    token_sac.mint(&sub_a, &10_000);
+    token_sac.mint(&sub_b, &10_000);
+
+    let contract_id = env.register(SubStreamContract, ());
+    let client = SubStreamContractClient::new(&env, &contract_id);
+    client.initialize(&admin);
+
+    let mut rng = OsRng;
+    let sk1 = ed25519_dalek::SigningKey::generate(&mut rng);
+    let sk2 = ed25519_dalek::SigningKey::generate(&mut rng);
+    let sk3 = ed25519_dalek::SigningKey::generate(&mut rng);
+    let jurors = vec![
+        &env,
+        BytesN::from_array(&env, &sk1.verifying_key().to_bytes()),
+        BytesN::from_array(&env, &sk2.verifying_key().to_bytes()),
+        BytesN::from_array(&env, &sk3.verifying_key().to_bytes()),
+    ];
+    client.configure_dispute_jurors(&admin, &jurors);
+
+    let plan = Plan {
+        plan_id: 1,
+        name: soroban_sdk::String::from_str(&env, "Plan"),
+        billing_amount: 100,
+        billing_cycle: MONTH,
+        has_trial: false,
+        trial_duration: 0,
+        is_active: true,
+    };
+    client.register_plan(&merchant, plan);
+
+    env.ledger().set_timestamp(10_000);
+    client.initialize_subscription(&sub_a, &merchant, &1, &token.address());
+    client.initialize_subscription(&sub_b, &merchant, &1, &token.address());
+
+    token.approve(&sub_a, &contract_id, &5000, &1_000_000u32);
+    token.approve(&sub_b, &contract_id, &5000, &1_000_000u32);
+
+    env.ledger().set_timestamp(10_000 + MONTH);
+    client.execute_subscription_pull(&merchant, &sub_a);
+    client.execute_subscription_pull(&merchant, &sub_b);
+
+    client.raise_dispute(&sub_a, &merchant, &5);
+    client.raise_dispute(&sub_b, &merchant, &7);
+
+    let d1 = client.get_active_dispute_id(&sub_a, &merchant).unwrap();
+    let d2 = client.get_active_dispute_id(&sub_b, &merchant).unwrap();
+    assert_ne!(d1, d2);
+
+    let r1 = client.get_dispute_record(&d1).unwrap();
+    let r2 = client.get_dispute_record(&d2).unwrap();
+    assert_eq!(r1.disputed_amount, 100);
+    assert_eq!(r1.bond_amount, 5);
+    assert_eq!(r2.disputed_amount, 100);
+    assert_eq!(r2.bond_amount, 7);
+
+    let sigs_user = vec![
+        &env,
+        sign_digest(&env, &sk1, d1, true),
+        sign_digest(&env, &sk2, d1, true),
+        sign_digest(&env, &sk3, d1, true),
+    ];
+    client.resolve_dispute_for_user(&sub_a, &merchant, &d1, &sigs_user);
+
+    let sigs_merchant = vec![
+        &env,
+        sign_digest(&env, &sk1, d2, false),
+        sign_digest(&env, &sk2, d2, false),
+        sign_digest(&env, &sk3, d2, false),
+    ];
+    client.resolve_dispute_for_merchant(&sub_b, &merchant, &d2, &sigs_merchant);
+
+    assert_eq!(token.balance(&sub_a), 10_000);
+    assert_eq!(token.balance(&sub_b), 9_893);
+    assert_eq!(token.balance(&merchant), 107);
+}

--- a/contracts/substream_contracts/src/test_enhanced_subscriptions.rs
+++ b/contracts/substream_contracts/src/test_enhanced_subscriptions.rs
@@ -53,7 +53,7 @@ fn test_execute_subscription_pull_success() {
     client.initialize_subscription(&subscriber, &merchant, &1, &token.address());
 
     // Set up allowance
-    token_client.approve(&subscriber, &contract_id, &1000);
+    token.approve(&subscriber, &contract_id, &1000, &1_000_000u32);
 
     // Jump to billing date
     env.ledger().set_timestamp(1000 + MONTH);
@@ -172,7 +172,7 @@ fn test_trial_period_auto_conversion() {
     );
 
     // Set up allowance for after trial
-    token_client.approve(&subscriber, &contract_id, &1000);
+    token.approve(&subscriber, &contract_id, &1000, &1_000_000u32);
 
     // Jump past trial period
     env.ledger().set_timestamp(1000 + 7 * DAY + 1);
@@ -282,7 +282,7 @@ fn test_grace_period_entry_and_recovery() {
     }));
 
     // Now provide allowance and recover
-    token_client.approve(&subscriber, &contract_id, &1000);
+    token.approve(&subscriber, &contract_id, &1000, &1_000_000u32);
     
     // Should succeed within grace period
     client.execute_subscription_pull(&merchant, &subscriber);
@@ -501,7 +501,7 @@ fn test_full_subscription_lifecycle() {
     );
 
     // Set up allowance for post-trial billing
-    token_client.approve(&subscriber, &contract_id, &1000);
+    token.approve(&subscriber, &contract_id, &1000, &1_000_000u32);
 
     // Jump past trial and upgrade to pro
     env.ledger().set_timestamp(1000 + 7 * DAY + 1);


### PR DESCRIPTION
Implement raise_dispute within a 48-hour window after a pull, hold the last billed amount in-contract, require a subscriber bond, pause further pulls while Disputed, and resolve via ed25519-verified juror signatures.

Add resolve_dispute_for_user and resolve_dispute_for_merchant paths, DisputeRaised/DisputeResolved events, admin-configured juror keys, and billing_dispute helpers. Fix lib merge issues (duplicate helpers, SLA emergency cancel, cancel unregister, Subscription DataKey).

Add overlapping dispute escrow isolation test and fix token approve calls for Soroban token interface.

Closes #117 