### PR TITLE
feat: add velocity-based circuit breaker for unsubscribe spikes

### DIFF
--- a/contracts/substream_contracts/fuzz/Cargo.toml
+++ b/contracts/substream_contracts/fuzz/Cargo.toml
@@ -31,3 +31,10 @@ path = "fuzz_targets/batch_import_signatures.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "cancel_velocity_breaker"
+path = "fuzz_targets/cancel_velocity_breaker.rs"
+test = false
+doc = false
+bench = false

--- a/contracts/substream_contracts/fuzz/fuzz_targets/cancel_velocity_breaker.rs
+++ b/contracts/substream_contracts/fuzz/fuzz_targets/cancel_velocity_breaker.rs
@@ -1,0 +1,94 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use soroban_sdk::testutils::{Address as _, Ledger};
+use soroban_sdk::{token, Address, Env, String};
+
+use substream_contracts::{CancelVelocityMetrics, SubStreamContract, SubStreamContractClient};
+
+const DAY: u64 = 24 * 60 * 60;
+const SEP12_ISSUER: &str =
+    "GD5DQX2K7Q4D4PE4R6J4Y7Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2";
+
+fn create_and_cancel_subscription(
+    env: &Env,
+    client: &SubStreamContractClient<'_>,
+    token_admin: &token::StellarAssetClient<'_>,
+    token_address: &Address,
+    merchant: &Address,
+    amount: i128,
+    rate: i128,
+) {
+    let subscriber = Address::generate(env);
+    token_admin.mint(&subscriber, &(amount.saturating_mul(2)));
+    client.subscribe(
+        &subscriber,
+        merchant,
+        token_address,
+        &amount,
+        &rate,
+        &None,
+    );
+    client.cancel(&subscriber, merchant);
+}
+
+fuzz_target!(|data: &[u8]| {
+    if data.len() < 4 {
+        return;
+    }
+
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let issuer = Address::from_string(&String::from_str(&env, SEP12_ISSUER));
+
+    let sac = env.register_stellar_asset_contract_v2(admin.clone());
+    let token_admin = token::StellarAssetClient::new(&env, &sac.address());
+
+    let contract_id = env.register(SubStreamContract, ());
+    let client = SubStreamContractClient::new(&env, &contract_id);
+    client.initialize(&admin);
+    client.register_merchant_with_kyc(&merchant, &soroban_sdk::vec![&env, 1u8], &issuer);
+
+    let baseline_days = (data[0] % 30) as u64;
+    let burst = 1 + (data[1] as usize % 64);
+    let amount = 5 + (data[2] as i128 % 50);
+    let rate = 1 + (data[3] as i128 % 5);
+
+    for day in 0..baseline_days {
+        env.ledger().set_timestamp(day.saturating_mul(DAY).saturating_add(10));
+        create_and_cancel_subscription(
+            &env,
+            &client,
+            &token_admin,
+            &sac.address(),
+            &merchant,
+            amount,
+            rate,
+        );
+    }
+
+    env.ledger()
+        .set_timestamp(baseline_days.saturating_mul(DAY).saturating_add(100));
+    for _ in 0..burst {
+        create_and_cancel_subscription(
+            &env,
+            &client,
+            &token_admin,
+            &sac.address(),
+            &merchant,
+            amount,
+            rate,
+        );
+    }
+
+    let metrics: CancelVelocityMetrics = client.get_cancel_velocity_metrics();
+    assert_eq!(metrics.hourly_bucket_count, 24);
+    assert_eq!(metrics.daily_bucket_count, 30);
+    if metrics.rolling_24h_cancellations > metrics.anomaly_threshold {
+        assert!(metrics.circuit_breaker_active);
+        assert!(metrics.soft_pause_active);
+    }
+});

--- a/contracts/substream_contracts/src/lib.rs
+++ b/contracts/substream_contracts/src/lib.rs
@@ -28,6 +28,14 @@ const SLA_THRESHOLD_BPS: u32 = 9990; // 99.9% uptime threshold (in basis points)
 const SEVEN_DAYS: u64 = 7 * 24 * 60 * 60;
 const UPTIME_ORACLE_NONCE_TTL: u64 = 24 * 60 * 60; // 24 hour validity for oracle signatures
 
+// --- Cancel Velocity Circuit Breaker Constants ---
+const DAY_IN_SECONDS: u64 = 24 * 60 * 60;
+const HOUR_IN_SECONDS: u64 = 60 * 60;
+const CANCEL_VELOCITY_HOURLY_BUCKETS: u32 = 24;
+const CANCEL_VELOCITY_DAILY_BUCKETS: u32 = 30;
+const CANCEL_VELOCITY_MULTIPLIER: u32 = 5; // 500% of 30d average
+const CANCEL_VELOCITY_MIN_TRIGGER: u32 = 25; // Ignore small protocols / cold start noise
+
 // --- Merchant Registry and KYC Whitelisting Constants ---
 pub(crate) const DAO_MULTISIG_THRESHOLD: u32 = 3; // Minimum signatures required for DAO decisions
 const MERCHANT_KYC_VALIDITY: u64 = 365 * 24 * 60 * 60; // 1 year validity for KYC credentials
@@ -104,6 +112,9 @@ pub enum DataKey {
     DaoGrant(Address, Address),        // (dao, creator) — DAO treasury grant stream
     UserContributed(Address, Address), // (fan, creator) — lifetime tokens contributed by fan
     TopFans(Address),                  // (creator) — Top 50 fans by contribution
+    CancelVelocityHourlyBuckets,
+    CancelVelocityDailyBuckets,
+    CancelVelocityBreakerState,
 }
 
 #[contracttype]
@@ -188,6 +199,45 @@ pub struct SLAStatus {
     pub cumulative_downtime_minutes: u64,
     pub current_penalty_period_start: u64,
     pub total_refund_owed: i128,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HourlyCancelBucket {
+    pub hour_epoch: u64,
+    pub count: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DailyCancelBucket {
+    pub day_epoch: u64,
+    pub count: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VelocityCircuitBreakerState {
+    pub active: bool,
+    pub soft_pause_active: bool,
+    pub triggered_at: u64,
+    pub last_updated: u64,
+    pub last_velocity: u32,
+    pub last_threshold: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CancelVelocityMetrics {
+    pub rolling_24h_cancellations: u32,
+    pub trailing_30d_cancellations: u32,
+    pub daily_average_30d: u32,
+    pub anomaly_threshold: u32,
+    pub circuit_breaker_active: bool,
+    pub soft_pause_active: bool,
+    pub triggered_at: u64,
+    pub hourly_bucket_count: u32,
+    pub daily_bucket_count: u32,
 }
 
 #[contracttype]
@@ -435,6 +485,13 @@ pub struct Unsubscribed {
     pub subscriber: Address,
     #[topic]
     pub creator: Address,
+}
+
+#[contractevent]
+pub struct VelocityAnomalyDetected {
+    pub current_velocity: u32,
+    pub threshold: u32,
+    pub timestamp: u64,
 }
 
 #[contractevent]
@@ -762,6 +819,8 @@ impl SubStreamContract {
         rate_per_second: i128,
         referrer: Option<Address>, // Add optional referrer parameter
     ) {
+        require_protocol_soft_pause_inactive(env);
+
         // Check if creator is a verified merchant (KYC or DAO approved)
         if !is_merchant_verified(&env, &creator) {
             panic!("creator is not a verified merchant");
@@ -866,6 +925,7 @@ impl SubStreamContract {
     }
 
     pub fn top_up(env: Env, subscriber: Address, stream_id: Address, amount: i128) {
+        require_protocol_soft_pause_inactive(&env);
         top_up_internal(&env, &subscriber, &stream_id, amount);
     }
 
@@ -873,7 +933,29 @@ impl SubStreamContract {
         cancel_internal(&env, &subscriber, &creator);
     }
 
+    pub fn get_cancel_velocity_metrics(env: Env) -> CancelVelocityMetrics {
+        sync_cancel_velocity_metrics(&env)
+    }
+
+    pub fn is_protocol_soft_paused(env: Env) -> bool {
+        read_velocity_circuit_breaker_state(&env).soft_pause_active
+    }
+
+    pub fn reset_cancel_velocity_circuit_breaker(env: Env, admin: Address) {
+        admin.require_auth();
+        require_contract_admin(&env, &admin);
+
+        let now = env.ledger().timestamp();
+        let mut state = read_velocity_circuit_breaker_state(&env);
+        state.active = false;
+        state.soft_pause_active = false;
+        state.triggered_at = 0;
+        state.last_updated = now;
+        write_velocity_circuit_breaker_state(&env, &state);
+    }
+
     pub fn tip(env: Env, user: Address, creator: Address, token: Address, amount: i128) {
+        require_protocol_soft_pause_inactive(&env);
         user.require_auth();
         if amount <= 0 || user == creator {
             panic!("invalid tip");
@@ -901,6 +983,8 @@ impl SubStreamContract {
         creators: soroban_sdk::Vec<Address>,
         percentages: soroban_sdk::Vec<u32>,
     ) {
+        require_protocol_soft_pause_inactive(&env);
+
         // Validate exactly 5 creators
         if creators.len() != 5 {
             panic!("group channel must contain exactly 5 creators");
@@ -1159,6 +1243,7 @@ impl SubStreamContract {
     
     // Helper function for merchants to register plans
     pub fn register_plan(env: Env, merchant: Address, plan: Plan) {
+        require_protocol_soft_pause_inactive(&env);
         merchant.require_auth();
 
         let plan_registry_key = DataKey::PlanRegistry(merchant.clone());
@@ -2257,6 +2342,13 @@ fn cancel_internal(env: &Env, beneficiary: &Address, stream_id: &Address) {
         .remove(&DataKey::PendingMerchantPull(beneficiary.clone(), stream_id.clone()));
     env.storage().persistent().remove(&key);
     env.storage().temporary().remove(&key);
+
+    record_protocol_cancellation(env);
+    Unsubscribed {
+        subscriber: beneficiary.clone(),
+        creator: stream_id.clone(),
+    }
+    .publish(env);
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -2354,6 +2446,288 @@ fn is_creator_paused(env: &Env, creator: &Address) -> bool {
         .persistent()
         .get(&DataKey::ChannelPaused(creator.clone()))
         .unwrap_or(false)
+}
+
+fn require_contract_admin(env: &Env, admin: &Address) {
+    let stored_admin: Address = env
+        .storage()
+        .persistent()
+        .get(&DataKey::ContractAdmin)
+        .expect("not initialized");
+    if admin != &stored_admin {
+        panic!("admin only");
+    }
+}
+
+fn require_protocol_soft_pause_inactive(env: &Env) {
+    if read_velocity_circuit_breaker_state(env).soft_pause_active {
+        panic!("protocol soft paused");
+    }
+}
+
+fn default_hourly_cancel_buckets(env: &Env) -> soroban_sdk::Vec<HourlyCancelBucket> {
+    let mut buckets = soroban_sdk::Vec::new(env);
+    for _ in 0..CANCEL_VELOCITY_HOURLY_BUCKETS {
+        buckets.push_back(HourlyCancelBucket {
+            hour_epoch: 0,
+            count: 0,
+        });
+    }
+    buckets
+}
+
+fn default_daily_cancel_buckets(env: &Env) -> soroban_sdk::Vec<DailyCancelBucket> {
+    let mut buckets = soroban_sdk::Vec::new(env);
+    for _ in 0..CANCEL_VELOCITY_DAILY_BUCKETS {
+        buckets.push_back(DailyCancelBucket {
+            day_epoch: 0,
+            count: 0,
+        });
+    }
+    buckets
+}
+
+fn default_velocity_circuit_breaker_state() -> VelocityCircuitBreakerState {
+    VelocityCircuitBreakerState {
+        active: false,
+        soft_pause_active: false,
+        triggered_at: 0,
+        last_updated: 0,
+        last_velocity: 0,
+        last_threshold: CANCEL_VELOCITY_MIN_TRIGGER,
+    }
+}
+
+fn read_hourly_cancel_buckets(env: &Env) -> soroban_sdk::Vec<HourlyCancelBucket> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::CancelVelocityHourlyBuckets)
+        .unwrap_or(default_hourly_cancel_buckets(env))
+}
+
+fn write_hourly_cancel_buckets(env: &Env, buckets: &soroban_sdk::Vec<HourlyCancelBucket>) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::CancelVelocityHourlyBuckets, buckets);
+    env.storage().persistent().extend_ttl(
+        &DataKey::CancelVelocityHourlyBuckets,
+        TTL_THRESHOLD,
+        TTL_BUMP_AMOUNT,
+    );
+}
+
+fn read_daily_cancel_buckets(env: &Env) -> soroban_sdk::Vec<DailyCancelBucket> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::CancelVelocityDailyBuckets)
+        .unwrap_or(default_daily_cancel_buckets(env))
+}
+
+fn write_daily_cancel_buckets(env: &Env, buckets: &soroban_sdk::Vec<DailyCancelBucket>) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::CancelVelocityDailyBuckets, buckets);
+    env.storage().persistent().extend_ttl(
+        &DataKey::CancelVelocityDailyBuckets,
+        TTL_THRESHOLD,
+        TTL_BUMP_AMOUNT,
+    );
+}
+
+fn read_velocity_circuit_breaker_state(env: &Env) -> VelocityCircuitBreakerState {
+    env.storage()
+        .persistent()
+        .get(&DataKey::CancelVelocityBreakerState)
+        .unwrap_or(default_velocity_circuit_breaker_state())
+}
+
+fn write_velocity_circuit_breaker_state(env: &Env, state: &VelocityCircuitBreakerState) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::CancelVelocityBreakerState, state);
+    env.storage().persistent().extend_ttl(
+        &DataKey::CancelVelocityBreakerState,
+        TTL_THRESHOLD,
+        TTL_BUMP_AMOUNT,
+    );
+}
+
+fn prune_hourly_cancel_buckets(now: u64, buckets: &mut soroban_sdk::Vec<HourlyCancelBucket>) {
+    let current_hour = now / HOUR_IN_SECONDS;
+    for i in 0..buckets.len() {
+        let mut bucket = buckets.get(i).unwrap();
+        if bucket.count > 0
+            && current_hour.saturating_sub(bucket.hour_epoch)
+                >= CANCEL_VELOCITY_HOURLY_BUCKETS as u64
+        {
+            bucket.hour_epoch = 0;
+            bucket.count = 0;
+            buckets.set(i, bucket);
+        }
+    }
+}
+
+fn prune_daily_cancel_buckets(now: u64, buckets: &mut soroban_sdk::Vec<DailyCancelBucket>) {
+    let current_day = now / DAY_IN_SECONDS;
+    for i in 0..buckets.len() {
+        let mut bucket = buckets.get(i).unwrap();
+        if bucket.count > 0
+            && current_day.saturating_sub(bucket.day_epoch)
+                >= CANCEL_VELOCITY_DAILY_BUCKETS as u64
+        {
+            bucket.day_epoch = 0;
+            bucket.count = 0;
+            buckets.set(i, bucket);
+        }
+    }
+}
+
+fn sum_hourly_cancel_buckets(now: u64, buckets: &soroban_sdk::Vec<HourlyCancelBucket>) -> u32 {
+    let current_hour = now / HOUR_IN_SECONDS;
+    let mut total = 0u32;
+    for i in 0..buckets.len() {
+        let bucket = buckets.get(i).unwrap();
+        if bucket.count > 0
+            && current_hour.saturating_sub(bucket.hour_epoch)
+                < CANCEL_VELOCITY_HOURLY_BUCKETS as u64
+        {
+            total = total.saturating_add(bucket.count);
+        }
+    }
+    total
+}
+
+fn sum_daily_cancel_buckets(now: u64, buckets: &soroban_sdk::Vec<DailyCancelBucket>) -> u32 {
+    let current_day = now / DAY_IN_SECONDS;
+    let mut total = 0u32;
+    for i in 0..buckets.len() {
+        let bucket = buckets.get(i).unwrap();
+        if bucket.count > 0
+            && current_day.saturating_sub(bucket.day_epoch)
+                < CANCEL_VELOCITY_DAILY_BUCKETS as u64
+        {
+            total = total.saturating_add(bucket.count);
+        }
+    }
+    total
+}
+
+fn calculate_cancel_velocity_threshold(trailing_30d_cancellations: u32) -> (u32, u32) {
+    let daily_average = if trailing_30d_cancellations == 0 {
+        0
+    } else {
+        (trailing_30d_cancellations + (CANCEL_VELOCITY_DAILY_BUCKETS - 1))
+            / CANCEL_VELOCITY_DAILY_BUCKETS
+    };
+    let baseline = daily_average.max(1);
+    let threshold = baseline
+        .saturating_mul(CANCEL_VELOCITY_MULTIPLIER)
+        .max(CANCEL_VELOCITY_MIN_TRIGGER);
+    (daily_average, threshold)
+}
+
+fn sync_cancel_velocity_metrics(env: &Env) -> CancelVelocityMetrics {
+    let now = env.ledger().timestamp();
+    let mut hourly_buckets = read_hourly_cancel_buckets(env);
+    let mut daily_buckets = read_daily_cancel_buckets(env);
+
+    prune_hourly_cancel_buckets(now, &mut hourly_buckets);
+    prune_daily_cancel_buckets(now, &mut daily_buckets);
+
+    let rolling_24h_cancellations = sum_hourly_cancel_buckets(now, &hourly_buckets);
+    let trailing_30d_cancellations = sum_daily_cancel_buckets(now, &daily_buckets);
+    let (daily_average_30d, anomaly_threshold) =
+        calculate_cancel_velocity_threshold(trailing_30d_cancellations);
+
+    let mut state = read_velocity_circuit_breaker_state(env);
+    state.last_updated = now;
+    state.last_velocity = rolling_24h_cancellations;
+    state.last_threshold = anomaly_threshold;
+
+    write_hourly_cancel_buckets(env, &hourly_buckets);
+    write_daily_cancel_buckets(env, &daily_buckets);
+    write_velocity_circuit_breaker_state(env, &state);
+
+    CancelVelocityMetrics {
+        rolling_24h_cancellations,
+        trailing_30d_cancellations,
+        daily_average_30d,
+        anomaly_threshold,
+        circuit_breaker_active: state.active,
+        soft_pause_active: state.soft_pause_active,
+        triggered_at: state.triggered_at,
+        hourly_bucket_count: hourly_buckets.len(),
+        daily_bucket_count: daily_buckets.len(),
+    }
+}
+
+fn record_protocol_cancellation(env: &Env) -> CancelVelocityMetrics {
+    let now = env.ledger().timestamp();
+    let current_hour = now / HOUR_IN_SECONDS;
+    let current_day = now / DAY_IN_SECONDS;
+
+    let mut hourly_buckets = read_hourly_cancel_buckets(env);
+    let mut daily_buckets = read_daily_cancel_buckets(env);
+    prune_hourly_cancel_buckets(now, &mut hourly_buckets);
+    prune_daily_cancel_buckets(now, &mut daily_buckets);
+
+    let hourly_idx = (current_hour % CANCEL_VELOCITY_HOURLY_BUCKETS as u64) as u32;
+    let daily_idx = (current_day % CANCEL_VELOCITY_DAILY_BUCKETS as u64) as u32;
+
+    let mut hour_bucket = hourly_buckets.get(hourly_idx).unwrap();
+    if hour_bucket.hour_epoch != current_hour {
+        hour_bucket.hour_epoch = current_hour;
+        hour_bucket.count = 0;
+    }
+    hour_bucket.count = hour_bucket.count.saturating_add(1);
+    hourly_buckets.set(hourly_idx, hour_bucket);
+
+    let mut day_bucket = daily_buckets.get(daily_idx).unwrap();
+    if day_bucket.day_epoch != current_day {
+        day_bucket.day_epoch = current_day;
+        day_bucket.count = 0;
+    }
+    day_bucket.count = day_bucket.count.saturating_add(1);
+    daily_buckets.set(daily_idx, day_bucket);
+
+    let rolling_24h_cancellations = sum_hourly_cancel_buckets(now, &hourly_buckets);
+    let trailing_30d_cancellations = sum_daily_cancel_buckets(now, &daily_buckets);
+    let (daily_average_30d, anomaly_threshold) =
+        calculate_cancel_velocity_threshold(trailing_30d_cancellations);
+
+    let mut state = read_velocity_circuit_breaker_state(env);
+    state.last_updated = now;
+    state.last_velocity = rolling_24h_cancellations;
+    state.last_threshold = anomaly_threshold;
+
+    if !state.active && rolling_24h_cancellations > anomaly_threshold {
+        state.active = true;
+        state.soft_pause_active = true;
+        state.triggered_at = now;
+
+        VelocityAnomalyDetected {
+            current_velocity: rolling_24h_cancellations,
+            threshold: anomaly_threshold,
+            timestamp: now,
+        }
+        .publish(env);
+    }
+
+    write_hourly_cancel_buckets(env, &hourly_buckets);
+    write_daily_cancel_buckets(env, &daily_buckets);
+    write_velocity_circuit_breaker_state(env, &state);
+
+    CancelVelocityMetrics {
+        rolling_24h_cancellations,
+        trailing_30d_cancellations,
+        daily_average_30d,
+        anomaly_threshold,
+        circuit_breaker_active: state.active,
+        soft_pause_active: state.soft_pause_active,
+        triggered_at: state.triggered_at,
+        hourly_bucket_count: hourly_buckets.len(),
+        daily_bucket_count: daily_buckets.len(),
+    }
 }
 
 // --- Referral Helper Functions ---
@@ -2570,3 +2944,5 @@ mod test_formal_verification;
 mod test_reentrancy_guard;
 #[cfg(test)]
 mod test_timelock_governance;
+#[cfg(test)]
+mod test_velocity_circuit_breaker;

--- a/contracts/substream_contracts/src/test_velocity_circuit_breaker.rs
+++ b/contracts/substream_contracts/src/test_velocity_circuit_breaker.rs
@@ -1,0 +1,172 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::testutils::{Address as _, Ledger};
+use soroban_sdk::{token, vec, Address, Env};
+
+fn seed_subscription(
+    env: &Env,
+    subscriber: &Address,
+    creator: &Address,
+    token_address: &Address,
+    balance_tokens: i128,
+) {
+    let now = env.ledger().timestamp();
+    let key = subscription_key(subscriber, creator);
+    let sub = Subscription {
+        token: token_address.clone(),
+        tier: Tier {
+            rate_per_second: 0,
+            trial_duration: 0,
+        },
+        balance: balance_tokens * PRECISION_MULTIPLIER,
+        last_collected: now,
+        start_time: now,
+        streak_start_date: now,
+        last_funds_exhausted: 0,
+        free_to_paid_emitted: false,
+        creators: vec![env, creator.clone()],
+        percentages: vec![env, 100u32],
+        payer: subscriber.clone(),
+        beneficiary: subscriber.clone(),
+        accrued_remainder: 0,
+    };
+
+    set_subscription(env, &key, &sub);
+    env.storage()
+        .persistent()
+        .set(&DataKey::CurrentFlowRate(creator.clone()), &0i128);
+}
+
+fn create_token_contract<'a>(env: &Env, admin: &Address) -> token::Client<'a> {
+    let sac = env.register_stellar_asset_contract_v2(admin.clone());
+    token::Client::new(env, &sac.address())
+}
+
+#[test]
+fn breaker_triggers_when_24h_velocity_exceeds_threshold() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    for day in 0..30u64 {
+        env.ledger()
+            .set_timestamp(day.saturating_mul(DAY_IN_SECONDS).saturating_add(10));
+        let metrics = record_protocol_cancellation(&env);
+        assert!(!metrics.circuit_breaker_active);
+    }
+
+    let baseline = sync_cancel_velocity_metrics(&env);
+    assert_eq!(baseline.daily_average_30d, 1);
+    assert_eq!(baseline.anomaly_threshold, CANCEL_VELOCITY_MIN_TRIGGER);
+
+    env.ledger()
+        .set_timestamp(29u64.saturating_mul(DAY_IN_SECONDS).saturating_add(100));
+
+    for _ in 0..24 {
+        let metrics = record_protocol_cancellation(&env);
+        assert!(!metrics.circuit_breaker_active);
+    }
+
+    let triggered = record_protocol_cancellation(&env);
+    assert!(triggered.circuit_breaker_active);
+    assert!(triggered.soft_pause_active);
+    assert_eq!(triggered.rolling_24h_cancellations, 26);
+    assert_eq!(triggered.anomaly_threshold, CANCEL_VELOCITY_MIN_TRIGGER);
+}
+
+#[test]
+fn normal_usage_does_not_false_positive() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    for day in 0..45u64 {
+        env.ledger()
+            .set_timestamp(day.saturating_mul(DAY_IN_SECONDS).saturating_add(10));
+        let metrics = record_protocol_cancellation(&env);
+        assert!(!metrics.circuit_breaker_active);
+    }
+
+    let metrics = sync_cancel_velocity_metrics(&env);
+    assert_eq!(metrics.daily_average_30d, 1);
+    assert!(!metrics.circuit_breaker_active);
+    assert_eq!(metrics.hourly_bucket_count, CANCEL_VELOCITY_HOURLY_BUCKETS);
+    assert_eq!(metrics.daily_bucket_count, CANCEL_VELOCITY_DAILY_BUCKETS);
+}
+
+#[test]
+fn soft_pause_blocks_top_up_but_cancel_still_works() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let subscriber = Address::generate(&env);
+    let creator = Address::generate(&env);
+
+    let token = create_token_contract(&env, &admin);
+    let token_admin = token::StellarAssetClient::new(&env, &token.address);
+    token_admin.mint(&subscriber, &100);
+
+    let contract_id = env.register(SubStreamContract, ());
+    let client = SubStreamContractClient::new(&env, &contract_id);
+    client.initialize(&admin);
+
+    env.ledger().set_timestamp(1_000);
+    seed_subscription(&env, &subscriber, &creator, &token.address, 10);
+
+    let mut state = read_velocity_circuit_breaker_state(&env);
+    state.active = true;
+    state.soft_pause_active = true;
+    write_velocity_circuit_breaker_state(&env, &state);
+
+    let top_up_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.top_up(&subscriber, &creator, &1);
+    }));
+    assert!(top_up_result.is_err());
+
+    client.cancel(&subscriber, &creator);
+    assert!(!subscription_exists(&env, &subscription_key(&subscriber, &creator)));
+}
+
+#[test]
+fn admin_can_reset_breaker_and_recover_protocol() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let contract_id = env.register(SubStreamContract, ());
+    let client = SubStreamContractClient::new(&env, &contract_id);
+    client.initialize(&admin);
+
+    let mut state = read_velocity_circuit_breaker_state(&env);
+    state.active = true;
+    state.soft_pause_active = true;
+    state.triggered_at = 77;
+    write_velocity_circuit_breaker_state(&env, &state);
+
+    env.ledger().set_timestamp(2_000);
+    client.reset_cancel_velocity_circuit_breaker(&admin);
+
+    let metrics = client.get_cancel_velocity_metrics();
+    assert!(!metrics.circuit_breaker_active);
+    assert!(!metrics.soft_pause_active);
+    assert_eq!(metrics.triggered_at, 0);
+}
+
+#[test]
+fn storage_remains_bounded_after_long_running_activity() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    for day in 0..120u64 {
+        env.ledger()
+            .set_timestamp(day.saturating_mul(DAY_IN_SECONDS).saturating_add(10));
+        for _ in 0..3 {
+            record_protocol_cancellation(&env);
+        }
+    }
+
+    let metrics = sync_cancel_velocity_metrics(&env);
+    assert_eq!(metrics.hourly_bucket_count, CANCEL_VELOCITY_HOURLY_BUCKETS);
+    assert_eq!(metrics.daily_bucket_count, CANCEL_VELOCITY_DAILY_BUCKETS);
+    assert!(metrics.trailing_30d_cancellations <= 90);
+}


### PR DESCRIPTION
Closes #113

## Summary
Implemented a velocity-based circuit breaker to detect and mitigate abnormal unsubscribe activity (e.g., bot/Sybil attacks) on the `cancel_subscription` flow. The system tracks cancellation velocity over time and triggers a soft pause when anomalies are detected, protecting the protocol and downstream indexers from abuse.

## Key Features
- Added bounded 24-hour and 30-day ring buffers for tracking cancellation velocity
- Introduced `CancelVelocityMetrics` and `VelocityCircuitBreakerState` for structured state management
- Implemented anomaly detection based on threshold comparison (e.g., 500% of 30-day moving average)
- Added `VelocityAnomalyDetected` event with relevant metadata (velocity, threshold, timestamp)
- Integrated soft-pause mechanism that restricts non-essential write operations while keeping `cancel_subscription` available
- Added admin function `reset_cancel_velocity_circuit_breaker` to manually clear the breaker state
- Ensured storage remains bounded and efficient

## Implementation Details
- `cancel_internal` now records every successful cancellation and feeds into the velocity tracking system
- Circuit breaker state is checked before executing non-essential protocol actions
- Ring buffer design ensures minimal storage overhead while preserving historical context
- Logic is structured to avoid false positives during normal usage patterns

## Testing
- Added unit tests (`test_velocity_circuit_breaker.rs`) covering:
  - Breaker trigger conditions
  - False-positive resistance under normal load
  - Behavior of `cancel_subscription` during active breaker state
  - Admin reset functionality
  - Storage bounds validation
- Added fuzz testing (`cancel_velocity_breaker.rs`) to simulate high-frequency cancellation attacks and validate robustness