### PR TITLE
Implement secure initialization pattern to prevent hijacking of maste…

### DIFF
--- a/contracts/substream_contracts/src/lib.rs
+++ b/contracts/substream_contracts/src/lib.rs
@@ -45,7 +45,6 @@ const CANCEL_VELOCITY_MIN_TRIGGER: u32 = 25; // Ignore small protocols / cold st
 // --- Merchant Registry and KYC Whitelisting Constants ---
 pub(crate) const DAO_MULTISIG_THRESHOLD: u32 = 3; // Minimum signatures required for DAO decisions
 const MERCHANT_KYC_VALIDITY: u64 = 365 * 24 * 60 * 60; // 1 year validity for KYC credentials
-const SEP12_KYC_ISSUER: &str = "GD5DQX2K7Q4D4PE4R6J4Y7Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2"; // SEP-12 KYC issuer address
 const TIMELOCK_DURATION: u64 = 48 * 60 * 60; // 48-hour timelock for registry updates
 const SECURITY_COUNCIL_SIZE: u32 = 5; // 5-member security council for multi-sig
 
@@ -144,6 +143,9 @@ pub enum DataKey {
     SecurityCouncilVeto(Address, u64),     // (council_member, proposal_id)
     // --- Merchant reference ID for webhook payloads (issue #130) ---
     MerchantReferenceId(Address, Address), // (subscriber, merchant)
+    // --- Secure Initialization Pattern (Issue #199) ---
+    ContractInitialized,                   // Flag to prevent re-initialization
+    KYCIssuer,                            // Configurable KYC issuer address
     // --- Misc persistent ---
     MinimumRate(Address),
     CommunityGoal(Address),
@@ -1235,20 +1237,73 @@ pub struct SubStreamContract;
 #[allow(clippy::too_many_arguments)]
 #[contractimpl]
 impl SubStreamContract {
-    /// Initialize the contract and set the contract admin.
+    /// Initialize the contract with secure initialization pattern (Issue #199).
+    ///
+    /// This function atomically initializes the contract admin, security council members,
+    /// and KYC issuer to prevent hijacking of the master merchant registry.
     ///
     /// # Arguments
     /// * `admin` — Address that will hold admin privileges.
+    /// * `security_council` — Exactly 5 addresses for the security council (3-of-5 multi-sig).
+    /// * `kyc_issuer` — Authorized SEP-12 KYC issuer address.
     ///
     /// # Errors
-    /// Panics if the contract has already been initialized.
-    pub fn initialize(env: Env, admin: Address) {
-        if env.storage().persistent().has(&DataKey::ContractAdmin) {
+    /// Panics if the contract has already been initialized, security council size is not 5,
+    /// or if any address is invalid.
+    pub fn initialize(
+        env: Env,
+        admin: Address,
+        security_council: soroban_sdk::Vec<Address>,
+        kyc_issuer: Address,
+    ) {
+        // Prevent re-initialization
+        if env.storage().persistent().has(&DataKey::ContractInitialized) {
             panic!("already initialized");
         }
+
+        // Validate security council size
+        if security_council.len() != SECURITY_COUNCIL_SIZE as usize {
+            panic!("security council must have exactly 5 members");
+        }
+
+        // Validate no duplicate security council members
+        for i in 0..security_council.len() {
+            for j in (i + 1)..security_council.len() {
+                if security_council.get(i).unwrap() == security_council.get(j).unwrap() {
+                    panic!("duplicate security council member");
+                }
+            }
+        }
+
+        let now = env.ledger().timestamp();
+
+        // Set contract admin
         env.storage()
             .persistent()
             .set(&DataKey::ContractAdmin, &admin);
+
+        // Set KYC issuer
+        env.storage()
+            .persistent()
+            .set(&DataKey::KYCIssuer, &kyc_issuer);
+
+        // Initialize security council members atomically
+        for i in 0..security_council.len() {
+            let member = security_council.get(i).unwrap();
+            let council_member = SecurityCouncilMember {
+                member: member.clone(),
+                added_at: now,
+                is_active: true,
+            };
+            env.storage()
+                .persistent()
+                .set(&DataKey::SecurityCouncilMember(member.clone()), &council_member);
+        }
+
+        // Set initialization flag to prevent re-initialization
+        env.storage()
+            .persistent()
+            .set(&DataKey::ContractInitialized, &true);
     }
 
     /// Grant verified-creator status to a creator address.
@@ -2190,37 +2245,12 @@ impl SubStreamContract {
         }.publish(&env);
     }
     
-    /// Initialize Security Council (5 members)
+    /// DEPRECATED: Security council initialization is now part of the main initialize function.
+    /// This function is kept for backward compatibility but will always fail.
+    /// Use the new initialize function with security council parameters instead.
+    #[deprecated(note = "Use initialize() with security council parameter")]
     pub fn initialize_security_council(env: Env, admin: Address, council_members: soroban_sdk::Vec<Address>) {
-        admin.require_auth();
-        
-        // Verify admin authorization
-        let stored_admin: Address = env
-            .storage()
-            .persistent()
-            .get(&DataKey::ContractAdmin)
-            .expect("not initialized");
-        if admin != stored_admin {
-            panic!("admin only");
-        }
-        
-        // Verify exactly 5 members
-        if council_members.len() != SECURITY_COUNCIL_SIZE as usize {
-            panic!("security council must have exactly 5 members");
-        }
-        
-        let now = env.ledger().timestamp();
-        
-        // Add all council members
-        for i in 0..council_members.len() {
-            let member = council_members.get(i).unwrap();
-            let council_member = SecurityCouncilMember {
-                member: member.clone(),
-                added_at: now,
-                is_active: true,
-            };
-            env.storage().persistent().set(&DataKey::SecurityCouncilMember(member.clone()), &council_member);
-        }
+        panic!("initialize_security_council is deprecated. Security council must be initialized atomically via initialize()");
     }
     
     // --- Merchant Registry and KYC Whitelisting Functions ---
@@ -2230,13 +2260,14 @@ impl SubStreamContract {
     /// # Arguments
     /// * `merchant` — Address of the merchant to register.
     /// * `kyc_credential_hash` — Hash of the KYC credential issued by the SEP-12 provider.
-    /// * `issuer` — Must match the authorized `SEP12_KYC_ISSUER` address.
+    /// * `issuer` — Must match the configured KYC issuer address.
     ///
     /// # Auth
     /// Requires `merchant` authorization.
     ///
     /// # Errors
-    /// Panics if the issuer is not the authorized SEP-12 KYC provider or the merchant is blacklisted.
+    /// Panics if the issuer is not the authorized KYC provider, the merchant is blacklisted,
+    /// or the contract is not properly initialized.
     pub fn register_merchant_with_kyc(
         env: Env,
         merchant: Address,
@@ -2244,33 +2275,27 @@ impl SubStreamContract {
         issuer: Address,
     ) {
         merchant.require_auth();
-        
-        // Verify issuer is authorized SEP-12 KYC provider
-        let authorized_issuer = Address::from_string(&soroban_sdk::String::from_str(&env, SEP12_KYC_ISSUER));
+
+        // Verify contract is properly initialized
+        if !is_contract_initialized(&env) {
+            panic!("contract not initialized");
+        }
+
+        // Verify issuer is authorized KYC provider (from configuration, not hardcoded)
+        let authorized_issuer: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::KYCIssuer)
+            .expect("KYC issuer not configured");
         if issuer != authorized_issuer {
             panic!("unauthorized KYC issuer");
         }
 
-        let elapsed = (now - charge_start) as i128;
-        let accrued = elapsed
-            .saturating_mul(grant.rate_per_second)
-            .saturating_add(grant.accrued_remainder);
-        let payout_tokens = accrued / PRECISION_MULTIPLIER;
-        let available_tokens = grant.balance / PRECISION_MULTIPLIER;
-        let actual_payout = payout_tokens.min(available_tokens);
-
-        if actual_payout > 0 {
-            let token_client = TokenClient::new(&env, &grant.token);
-            token_client.transfer(&env.current_contract_address(), &creator, &actual_payout);
-            credit_creator_earnings(&env, &creator, actual_payout);
-            credit_fan_contribution(&env, &grant.dao, &creator, actual_payout);
-        }
-        
         // Check if merchant is blacklisted
         if is_merchant_blacklisted(&env, &merchant) {
             panic!("merchant is blacklisted");
         }
-        
+
         let now = env.ledger().timestamp();
         
         // Create KYC credential
@@ -2489,6 +2514,26 @@ impl SubStreamContract {
         env.storage().persistent()
             .get(&DataKey::MerchantRegistry(merchant))
             .expect("merchant not found")
+    }
+
+    // --- Secure Initialization Helper Functions (Issue #199) ---
+
+    /// Returns `true` if the contract has been properly initialized.
+    pub fn is_initialized(env: Env) -> bool {
+        env.storage()
+            .persistent()
+            .has(&DataKey::ContractInitialized)
+    }
+
+    /// Returns the configured KYC issuer address.
+    ///
+    /// # Errors
+    /// Panics if the contract is not initialized.
+    pub fn get_kyc_issuer(env: Env) -> Address {
+        env.storage()
+            .persistent()
+            .get(&DataKey::KYCIssuer)
+            .expect("contract not initialized")
     }
 
     // --- Anonymous Subscription Verification with Nullifier Tracking ---
@@ -4972,6 +5017,15 @@ fn get_current_plan_id(env: &Env, merchant: &Address, billing_amount: i128) -> u
         }
     }
     0 // Default plan ID if not found
+}
+
+// --- Secure Initialization Helper Functions (Issue #199) ---
+
+/// Internal helper to check if the contract has been properly initialized.
+fn is_contract_initialized(env: &Env) -> bool {
+    env.storage()
+        .persistent()
+        .has(&DataKey::ContractInitialized)
 }
 
 // --- Global Reentrancy Guard Helper Functions ---

--- a/contracts/substream_contracts/src/test_merchant_registry.rs
+++ b/contracts/substream_contracts/src/test_merchant_registry.rs
@@ -14,10 +14,18 @@ fn test_merchant_registration_with_kyc() {
     let admin = Address::random(&env);
     let merchant = Address::random(&env);
     let kyc_issuer = Address::from_string(&soroban_sdk::String::from_str(&env, "GD5DQX2K7Q4D4PE4R6J4Y7Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2"));
-    
-    // Initialize contract
-    SubStreamContract::initialize(env.clone(), admin.clone());
-    
+
+    // Create security council members
+    let council_member1 = Address::random(&env);
+    let council_member2 = Address::random(&env);
+    let council_member3 = Address::random(&env);
+    let council_member4 = Address::random(&env);
+    let council_member5 = Address::random(&env);
+    let security_council = vec![&env, council_member1.clone(), council_member2.clone(), council_member3.clone(), council_member4.clone(), council_member5.clone()];
+
+    // Initialize contract with security council and KYC issuer
+    SubStreamContract::initialize(env.clone(), admin.clone(), security_council, kyc_issuer.clone());
+
     // Register merchant with valid KYC
     let kyc_hash = vec![&env; 32u8]; // Mock KYC hash
     SubStreamContract::register_merchant_with_kyc(
@@ -26,15 +34,15 @@ fn test_merchant_registration_with_kyc() {
         kyc_hash.clone(),
         kyc_issuer.clone(),
     );
-    
+
     // Verify merchant is registered and verified
     assert!(SubStreamContract::is_merchant_verified(env.clone(), merchant.clone()));
-    
+
     let merchant_status = SubStreamContract::get_merchant_status(env.clone(), merchant.clone());
     assert!(merchant_status.is_verified);
     assert!(!merchant_status.is_blacklisted);
     assert!(matches!(merchant_status.verification_method, VerificationMethod::SEP12KYC));
-    
+
     // Verify KYC credential is stored
     let kyc_credential_key = DataKey::KYCCredential(merchant.clone());
     let stored_kyc: KYCCredential = env.storage().persistent().get(&kyc_credential_key).unwrap();
@@ -50,11 +58,20 @@ fn test_merchant_registration_unauthorized_issuer() {
     let contract_id = env.register_contract(None, SubStreamContract);
     let admin = Address::random(&env);
     let merchant = Address::random(&env);
+    let kyc_issuer = Address::from_string(&soroban_sdk::String::from_str(&env, "GD5DQX2K7Q4D4PE4R6J4Y7Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2"));
     let unauthorized_issuer = Address::random(&env);
-    
-    // Initialize contract
-    SubStreamContract::initialize(env.clone(), admin.clone());
-    
+
+    // Create security council members
+    let council_member1 = Address::random(&env);
+    let council_member2 = Address::random(&env);
+    let council_member3 = Address::random(&env);
+    let council_member4 = Address::random(&env);
+    let council_member5 = Address::random(&env);
+    let security_council = vec![&env, council_member1.clone(), council_member2.clone(), council_member3.clone(), council_member4.clone(), council_member5.clone()];
+
+    // Initialize contract with security council and KYC issuer
+    SubStreamContract::initialize(env.clone(), admin.clone(), security_council, kyc_issuer.clone());
+
     // Try to register merchant with unauthorized KYC issuer
     let kyc_hash = vec![&env; 32u8];
     let result = env.try_invoke_contract::<(), (
@@ -64,7 +81,7 @@ fn test_merchant_registration_unauthorized_issuer() {
         &kyc_hash,
         &unauthorized_issuer,
     );
-    
+
     // Should fail with unauthorized KYC issuer error
     assert!(result.is_err());
     assert!(!SubStreamContract::is_merchant_verified(env.clone(), merchant.clone()));
@@ -77,9 +94,18 @@ fn test_dao_proposal_and_approval() {
     let admin = Address::random(&env);
     let merchant = Address::random(&env);
     let proposer = Address::random(&env);
-    
-    // Initialize contract
-    SubStreamContract::initialize(env.clone(), admin.clone());
+    let kyc_issuer = Address::random(&env);
+
+    // Create security council members
+    let council_member1 = Address::random(&env);
+    let council_member2 = Address::random(&env);
+    let council_member3 = Address::random(&env);
+    let council_member4 = Address::random(&env);
+    let council_member5 = Address::random(&env);
+    let security_council = vec![&env, council_member1.clone(), council_member2.clone(), council_member3.clone(), council_member4.clone(), council_member5.clone()];
+
+    // Initialize contract with security council and KYC issuer
+    SubStreamContract::initialize(env.clone(), admin.clone(), security_council, kyc_issuer);
     
     // First register merchant (without KYC for DAO approval test)
     let merchant_status = MerchantStatus {
@@ -129,9 +155,17 @@ fn test_merchant_blacklisting() {
     let admin = Address::random(&env);
     let merchant = Address::random(&env);
     let kyc_issuer = Address::from_string(&soroban_sdk::String::from_str(&env, "GD5DQX2K7Q4D4PE4R6J4Y7Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2"));
-    
-    // Initialize contract
-    SubStreamContract::initialize(env.clone(), admin.clone());
+
+    // Create security council members
+    let council_member1 = Address::random(&env);
+    let council_member2 = Address::random(&env);
+    let council_member3 = Address::random(&env);
+    let council_member4 = Address::random(&env);
+    let council_member5 = Address::random(&env);
+    let security_council = vec![&env, council_member1.clone(), council_member2.clone(), council_member3.clone(), council_member4.clone(), council_member5.clone()];
+
+    // Initialize contract with security council and KYC issuer
+    SubStreamContract::initialize(env.clone(), admin.clone(), security_council, kyc_issuer.clone());
     
     // Register merchant with KYC
     let kyc_hash = vec![&env; 32u8];
@@ -169,9 +203,18 @@ fn test_subscription_to_unverified_merchant_fails() {
     let subscriber = Address::random(&env);
     let unverified_merchant = Address::random(&env);
     let token = Address::random(&env);
-    
-    // Initialize contract
-    SubStreamContract::initialize(env.clone(), admin.clone());
+    let kyc_issuer = Address::random(&env);
+
+    // Create security council members
+    let council_member1 = Address::random(&env);
+    let council_member2 = Address::random(&env);
+    let council_member3 = Address::random(&env);
+    let council_member4 = Address::random(&env);
+    let council_member5 = Address::random(&env);
+    let security_council = vec![&env, council_member1.clone(), council_member2.clone(), council_member3.clone(), council_member4.clone(), council_member5.clone()];
+
+    // Initialize contract with security council and KYC issuer
+    SubStreamContract::initialize(env.clone(), admin.clone(), security_council, kyc_issuer);
     
     // Try to subscribe to unverified merchant
     let result = env.try_invoke_contract::<(), (
@@ -198,9 +241,17 @@ fn test_subscription_to_blacklisted_merchant_fails() {
     let merchant = Address::random(&env);
     let kyc_issuer = Address::from_string(&soroban_sdk::String::from_str(&env, "GD5DQX2K7Q4D4PE4R6J4Y7Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2"));
     let token = Address::random(&env);
-    
-    // Initialize contract
-    SubStreamContract::initialize(env.clone(), admin.clone());
+
+    // Create security council members
+    let council_member1 = Address::random(&env);
+    let council_member2 = Address::random(&env);
+    let council_member3 = Address::random(&env);
+    let council_member4 = Address::random(&env);
+    let council_member5 = Address::random(&env);
+    let security_council = vec![&env, council_member1.clone(), council_member2.clone(), council_member3.clone(), council_member4.clone(), council_member5.clone()];
+
+    // Initialize contract with security council and KYC issuer
+    SubStreamContract::initialize(env.clone(), admin.clone(), security_council, kyc_issuer.clone());
     
     // Register merchant with KYC
     let kyc_hash = vec![&env; 32u8];
@@ -244,9 +295,17 @@ fn test_blacklisted_merchant_cannot_collect_funds() {
     let merchant = Address::random(&env);
     let kyc_issuer = Address::from_string(&soroban_sdk::String::from_str(&env, "GD5DQX2K7Q4D4PE4R6J4Y7Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2"));
     let token = Address::random(&env);
-    
-    // Initialize contract
-    SubStreamContract::initialize(env.clone(), admin.clone());
+
+    // Create security council members
+    let council_member1 = Address::random(&env);
+    let council_member2 = Address::random(&env);
+    let council_member3 = Address::random(&env);
+    let council_member4 = Address::random(&env);
+    let council_member5 = Address::random(&env);
+    let security_council = vec![&env, council_member1.clone(), council_member2.clone(), council_member3.clone(), council_member4.clone(), council_member5.clone()];
+
+    // Initialize contract with security council and KYC issuer
+    SubStreamContract::initialize(env.clone(), admin.clone(), security_council, kyc_issuer.clone());
     
     // Register merchant with KYC
     let kyc_hash = vec![&env; 32u8];
@@ -293,9 +352,17 @@ fn test_merchant_cannot_register_twice() {
     let admin = Address::random(&env);
     let merchant = Address::random(&env);
     let kyc_issuer = Address::from_string(&soroban_sdk::String::from_str(&env, "GD5DQX2K7Q4D4PE4R6J4Y7Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2"));
-    
-    // Initialize contract
-    SubStreamContract::initialize(env.clone(), admin.clone());
+
+    // Create security council members
+    let council_member1 = Address::random(&env);
+    let council_member2 = Address::random(&env);
+    let council_member3 = Address::random(&env);
+    let council_member4 = Address::random(&env);
+    let council_member5 = Address::random(&env);
+    let security_council = vec![&env, council_member1.clone(), council_member2.clone(), council_member3.clone(), council_member4.clone(), council_member5.clone()];
+
+    // Initialize contract with security council and KYC issuer
+    SubStreamContract::initialize(env.clone(), admin.clone(), security_council, kyc_issuer.clone());
     
     // Register merchant with KYC
     let kyc_hash = vec![&env; 32u8];
@@ -328,9 +395,18 @@ fn test_dao_proposal_voting_mechanism() {
     let proposer = Address::random(&env);
     let voter1 = Address::random(&env);
     let voter2 = Address::random(&env);
-    
-    // Initialize contract
-    SubStreamContract::initialize(env.clone(), admin.clone());
+    let kyc_issuer = Address::random(&env);
+
+    // Create security council members
+    let council_member1 = Address::random(&env);
+    let council_member2 = Address::random(&env);
+    let council_member3 = Address::random(&env);
+    let council_member4 = Address::random(&env);
+    let council_member5 = Address::random(&env);
+    let security_council = vec![&env, council_member1.clone(), council_member2.clone(), council_member3.clone(), council_member4.clone(), council_member5.clone()];
+
+    // Initialize contract with security council and KYC issuer
+    SubStreamContract::initialize(env.clone(), admin.clone(), security_council, kyc_issuer);
     
     // Set up merchant for proposal
     let merchant_status = MerchantStatus {
@@ -371,10 +447,18 @@ fn test_events_emission() {
     let contract_id = env.register_contract(None, SubStreamContract);
     let admin = Address::random(&env);
     let merchant = Address::random(&env);
-    let kyc_issuer = Address::from_string(&soroban_sdk::String::from_str(&env, "GD5DQX2K7Q4D4PE4R6J4Y7Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2"));
-    
-    // Initialize contract
-    SubStreamContract::initialize(env.clone(), admin.clone());
+    let kyc_issuer = Address::from_string(&soroban_sdk::String::from_str(&env, "GD5DQX2K7Q4D4PE4R6J4Y7Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2Q2"));
+
+    // Create security council members
+    let council_member1 = Address::random(&env);
+    let council_member2 = Address::random(&env);
+    let council_member3 = Address::random(&env);
+    let council_member4 = Address::random(&env);
+    let council_member5 = Address::random(&env);
+    let security_council = vec![&env, council_member1.clone(), council_member2.clone(), council_member3.clone(), council_member4.clone(), council_member5.clone()];
+
+    // Initialize contract with security council and KYC issuer
+    SubStreamContract::initialize(env.clone(), admin.clone(), security_council, kyc_issuer.clone());
     
     // Register merchant and check events
     let kyc_hash = vec![&env; 32u8];


### PR DESCRIPTION
Closes #199

---

…r merchant registry (Issue #199)

- Remove hardcoded SEP12_KYC_ISSUER constant
- Add ContractInitialized and KYCIssuer to DataKey enum
- Update initialize() to atomically set admin, security council (5 members), and KYC issuer
- Add initialization flag to prevent re-initialization
- Deprecated separate initialize_security_council() function
- Update register_merchant_with_kyc() to use configured KYC issuer
- Add helper functions: is_initialized() and get_kyc_issuer()
- Update all tests to use new initialize signature
- Validate security council has exactly 5 unique members
- Ensure merchant operations require proper initialization